### PR TITLE
Add clearer separation between message and promo text

### DIFF
--- a/src/helpers/addPromoToText.ts
+++ b/src/helpers/addPromoToText.ts
@@ -6,5 +6,5 @@ import promoTexts from '@/helpers/promoTexts'
 export default function addPromoToText(ctx: Context, text: string) {
   return promoExceptions.includes(+ctx.dbchat.id)
     ? text
-    : `${text}\n${isRuChat(ctx.dbchat) ? promoTexts.ru() : promoTexts.en()}`
+    : `${text}\n\n\n${isRuChat(ctx.dbchat) ? promoTexts.ru() : promoTexts.en()}`
 }


### PR DESCRIPTION
Also see #84 (the *It gives the impression that the audio says that, when in fact it does not.* part). This is indeed something that has happened in group chat's I'm in before - people didn't understand that the message isn't actually part of what the person speaking said.

I haven't actually tested this, but I imagine it to look like this - before:

![image](https://user-images.githubusercontent.com/625793/179259779-4101bd7a-90c0-4011-952b-7710af665edf.png)

After:

![image](https://user-images.githubusercontent.com/625793/179259811-710c59e9-3dda-45ef-82ac-f4a51f35acdc.png)

---

Also, thanks a lot for Voicy! :sparkles: As someone who hates voice messages (especially in group chats...), this has been a lifesaver.