### PR TITLE
Add extra line to promo texts

### DIFF
--- a/src/helpers/addPromoToText.ts
+++ b/src/helpers/addPromoToText.ts
@@ -6,5 +6,5 @@ import promoTexts from '@/helpers/promoTexts'
 export default function addPromoToText(ctx: Context, text: string) {
   return promoExceptions.includes(+ctx.dbchat.id)
     ? text
-    : `${text}\n${isRuChat(ctx.dbchat) ? promoTexts.ru() : promoTexts.en()}`
+    : `${text}\n\n${isRuChat(ctx.dbchat) ? promoTexts.ru() : promoTexts.en()}`
 }


### PR DESCRIPTION
This adds an extra line to promo texts (and thus, the war notification), so that it can be better distinguished from the actual message.

Some messages might be long enough to just fit until the end of a line, in which case the promo text might look like part of the message that was sent.
