### PR TITLE
Refactor duplicated Voicy command paths

### DIFF
--- a/src/commands/handleFiles.ts
+++ b/src/commands/handleFiles.ts
@@ -1,14 +1,11 @@
 import Context from '@/models/Context'
-import logAnswerTime from '@/helpers/logAnswerTime'
+import toggleChatBoolean from '@/helpers/toggleChatBoolean'
 
 export default async function handleFiles(ctx: Context) {
-  ctx.dbchat.filesBanned = !ctx.dbchat.filesBanned
-  await ctx.dbchat.save()
-  await ctx.reply(
-    ctx.i18n.t(ctx.dbchat.filesBanned ? 'files_false' : 'files_true'),
-    {
-      parse_mode: 'Markdown',
-    }
-  )
-  logAnswerTime(ctx, '/files')
+  await toggleChatBoolean(ctx, {
+    setting: 'filesBanned',
+    messageForValue: (filesBanned) =>
+      filesBanned ? 'files_false' : 'files_true',
+    logLabel: '/files',
+  })
 }

--- a/src/commands/handleSilent.ts
+++ b/src/commands/handleSilent.ts
@@ -1,14 +1,10 @@
 import Context from '@/models/Context'
-import logAnswerTime from '@/helpers/logAnswerTime'
+import toggleChatBoolean from '@/helpers/toggleChatBoolean'
 
 export default async function handleSilent(ctx: Context) {
-  ctx.dbchat.silent = !ctx.dbchat.silent
-  await ctx.dbchat.save()
-  await ctx.reply(
-    ctx.i18n.t(ctx.dbchat.silent ? 'silent_true' : 'silent_false'),
-    {
-      parse_mode: 'Markdown',
-    }
-  )
-  logAnswerTime(ctx, '/silent')
+  await toggleChatBoolean(ctx, {
+    setting: 'silent',
+    messageForValue: (silent) => (silent ? 'silent_true' : 'silent_false'),
+    logLabel: '/silent',
+  })
 }

--- a/src/commands/handleTimecodes.ts
+++ b/src/commands/handleTimecodes.ts
@@ -1,16 +1,11 @@
 import Context from '@/models/Context'
-import logAnswerTime from '@/helpers/logAnswerTime'
+import toggleChatBoolean from '@/helpers/toggleChatBoolean'
 
 export default async function handleTimecodes(ctx: Context) {
-  ctx.dbchat.timecodesEnabled = !ctx.dbchat.timecodesEnabled
-  await ctx.dbchat.save()
-  await ctx.reply(
-    ctx.i18n.t(
-      ctx.dbchat.timecodesEnabled ? 'timecodes_true' : 'timecodes_false'
-    ),
-    {
-      parse_mode: 'Markdown',
-    }
-  )
-  logAnswerTime(ctx, '/timecodes')
+  await toggleChatBoolean(ctx, {
+    setting: 'timecodesEnabled',
+    messageForValue: (timecodesEnabled) =>
+      timecodesEnabled ? 'timecodes_true' : 'timecodes_false',
+    logLabel: '/timecodes',
+  })
 }

--- a/src/commands/handleTranscribe.ts
+++ b/src/commands/handleTranscribe.ts
@@ -1,25 +1,13 @@
-import { ChatModel } from '@/models/Chat'
 import { sendTranscription } from '@/handlers/handleAudio'
 import Context from '@/models/Context'
+import ensurePaidChat from '@/helpers/ensurePaidChat'
 import fileUrl from '@/helpers/fileUrl'
 import report from '@/helpers/report'
 
 export default async function handleTranscribe(ctx: Context) {
   try {
-    if (!ctx.dbchat.paid) {
-      console.log('Sending the donate message')
-      await ctx.reply(ctx.i18n.t('sunsetting'), {
-        parse_mode: 'Markdown',
-        reply_to_message_id: ctx.msg.message_id,
-        disable_web_page_preview: true,
-      })
+    if (!(await ensurePaidChat(ctx))) {
       return
-    }
-    if (!ctx.dbchat.paid) {
-      await ChatModel.updateOne(
-        { id: ctx.dbchat.id },
-        { $inc: { freeVoicesUsed: 1 } }
-      )
     }
 
     const message = ctx.msg.reply_to_message

--- a/src/commands/handleTranscribeAll.ts
+++ b/src/commands/handleTranscribeAll.ts
@@ -1,18 +1,11 @@
 import Context from '@/models/Context'
-import logAnswerTime from '@/helpers/logAnswerTime'
+import toggleChatBoolean from '@/helpers/toggleChatBoolean'
 
 export default async function handleTranscribeAll(ctx: Context) {
-  ctx.dbchat.transcribeAllAudio = !ctx.dbchat.transcribeAllAudio
-  await ctx.dbchat.save()
-  await ctx.reply(
-    ctx.i18n.t(
-      !ctx.dbchat.transcribeAllAudio
-        ? 'transcribe_all_false'
-        : 'transcribe_all_true'
-    ),
-    {
-      parse_mode: 'Markdown',
-    }
-  )
-  logAnswerTime(ctx, 'handleTranscribeAll')
+  await toggleChatBoolean(ctx, {
+    setting: 'transcribeAllAudio',
+    messageForValue: (transcribeAllAudio) =>
+      transcribeAllAudio ? 'transcribe_all_true' : 'transcribe_all_false',
+    logLabel: 'handleTranscribeAll',
+  })
 }

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -1,30 +1,19 @@
-import { Chat, ChatModel } from '@/models/Chat'
+import { Chat } from '@/models/Chat'
 import { Message } from '@grammyjs/types'
 import { addVoice } from '@/models/Voice'
 import { pick } from 'lodash'
 import Context from '@/models/Context'
 import Engine from '@/helpers/engine/Engine'
 import addPromoToText from '@/helpers/addPromoToText'
+import ensurePaidChat from '@/helpers/ensurePaidChat'
 import fileUrl from '@/helpers/fileUrl'
 import report from '@/helpers/report'
 import urlToText from '@/helpers/urlToText'
 
 export default async function handleAudio(ctx: Context) {
   try {
-    if (!ctx.dbchat.paid) {
-      console.log('Sending the donate message')
-      await ctx.reply(ctx.i18n.t('sunsetting'), {
-        parse_mode: 'Markdown',
-        reply_to_message_id: ctx.msg.message_id,
-        disable_web_page_preview: true,
-      })
+    if (!(await ensurePaidChat(ctx))) {
       return
-    }
-    if (!ctx.dbchat.paid) {
-      await ChatModel.updateOne(
-        { id: ctx.dbchat.id },
-        { $inc: { freeVoicesUsed: 1 } }
-      )
     }
     // In a group or supergroup, only transcribe if transcribeAllAudio is true
     const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup'

--- a/src/helpers/ensurePaidChat.ts
+++ b/src/helpers/ensurePaidChat.ts
@@ -1,0 +1,13 @@
+import Context from '@/models/Context'
+
+export default async function ensurePaidChat(ctx: Context) {
+  if (ctx.dbchat.paid) {
+    return true
+  }
+  await ctx.reply(ctx.i18n.t('sunsetting'), {
+    parse_mode: 'Markdown',
+    reply_to_message_id: ctx.msg.message_id,
+    disable_web_page_preview: true,
+  })
+  return false
+}

--- a/src/helpers/report.ts
+++ b/src/helpers/report.ts
@@ -1,41 +1,4 @@
 import Context from '@/models/Context'
-import bot from '@/helpers/bot'
-
-const ignoredMessages = [
-  'have no rights to send a message',
-  'You have exceeded the limit of 60 requests per minute for your app',
-  "message can't be deleted",
-  'message is not modified',
-  'replied message not found',
-  'CHAT_WRITE_FORBIDDEN',
-  'message to edit not found',
-  'Exceeded max audio length of 20 seconds',
-  'Response code 404 (Not Found)',
-  'Too Many Requests: retry after',
-  'You have exceeded the limit of 240 requests',
-  'MESSAGE_ID_INVALID',
-  'bot was kicked from the supergroup chat',
-  'The project to be billed is associated with a delinquent billing account',
-  'need administrator rights',
-  'You have exceeded the limit of 180 requests',
-  'The project to be billed is associated with a closed billing account',
-  'wrong file_id or the file is temporarily unavailable',
-  'not enough rights to send text messages',
-  'bot was blocked by the user',
-  'bot was kicked from the group chat',
-  'bot is not a member of the supergroup chat',
-  'The project to be billed is associated with an absent billing',
-  'Bad Request: not Found',
-  'account not found',
-  'Request Entity Too Large',
-  'Does not contain any stream',
-  'ffprobe exited with code 1',
-  'Invalid duration specification for t',
-  'Timeout, please try again later',
-  '504: Gateway Timeout',
-  'does not have storage.buckets.create access',
-  'bucket name is needed to use Cloud Storage',
-]
 
 interface ExtraErrorInfo {
   ctx?: Context
@@ -43,31 +6,6 @@ interface ExtraErrorInfo {
   meta?: string
 }
 
-function constructErrorMessage(
-  error: Error,
-  { ctx, location, meta }: ExtraErrorInfo
-) {
-  const { message } = error
-  const chatInfo = ctx ? [`Chat <b>${ctx.chat.id}</b>`] : []
-  if (ctx && 'username' in ctx.chat) {
-    chatInfo.push(`@${ctx.chat.username}`)
-  }
-  if (ctx && ctx.dbchat) {
-    chatInfo.push(ctx.dbchat.engine)
-    chatInfo.push(ctx.dbchat.languages[ctx.dbchat.engine])
-  }
-  const result = `${
-    location ? `<b>${escape(location)}</b>${ctx ? '\n' : ''}` : ''
-  }${chatInfo.filter((v) => !!v).join(', ')}\n${escape(message)}${
-    meta ? `${meta}\n` : ''
-  }`
-  return result
-}
-
 export default function report(error: Error, info: ExtraErrorInfo = {}) {
   console.log(error, info)
-}
-
-function escape(s: string) {
-  return s.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/&/g, '&amp;')
 }

--- a/src/helpers/toggleChatBoolean.ts
+++ b/src/helpers/toggleChatBoolean.ts
@@ -1,0 +1,26 @@
+import Context from '@/models/Context'
+import logAnswerTime from '@/helpers/logAnswerTime'
+
+type BooleanChatSetting =
+  | 'filesBanned'
+  | 'silent'
+  | 'timecodesEnabled'
+  | 'transcribeAllAudio'
+
+interface ToggleChatBooleanOptions {
+  setting: BooleanChatSetting
+  messageForValue: (value: boolean) => string
+  logLabel: string
+}
+
+export default async function toggleChatBoolean(
+  ctx: Context,
+  { setting, messageForValue, logLabel }: ToggleChatBooleanOptions
+) {
+  ctx.dbchat[setting] = !ctx.dbchat[setting]
+  await ctx.dbchat.save()
+  await ctx.reply(ctx.i18n.t(messageForValue(ctx.dbchat[setting])), {
+    parse_mode: 'Markdown',
+  })
+  logAnswerTime(ctx, logLabel)
+}

--- a/src/models/Chat.ts
+++ b/src/models/Chat.ts
@@ -55,8 +55,6 @@ export class Chat extends FindOrCreate {
   paid: boolean
   @prop({ required: true, default: false })
   banned: boolean
-  @prop({ required: true, default: 0 })
-  freeVoicesUsed: number
 }
 
 export const ChatModel = getModelForClass(Chat)


### PR DESCRIPTION
## Summary
- Consolidate repeated paid-chat guard logic for audio transcription and /transcribe
- Consolidate repeated boolean toggle command handlers for files, silent mode, timecodes, and transcribe-all
- Remove dead legacy report formatting code and the unused freeVoicesUsed model path

## Validation
- COREPACK_ENABLE_AUTO_PIN=0 yarn build-ts
- COREPACK_ENABLE_AUTO_PIN=0 yarn lint