### PR TITLE
Build authenticated Voicy worker API

### DIFF
--- a/docs/worker-api.md
+++ b/docs/worker-api.md
@@ -1,0 +1,96 @@
+# Voicy Worker API
+
+Worker clients authenticate with `Authorization: Bearer <token>`. Tokens are
+stored in Mongo only as SHA-256 hashes in `WorkerClient`.
+
+Create a token after building the TypeScript output:
+
+```sh
+yarn build-ts
+MONGO='mongodb://...' yarn worker:create-client windows-4070-ti
+```
+
+## Endpoints
+
+All endpoints are mounted under `/worker/v1`.
+
+### `POST /jobs/claim`
+
+Atomically claims the oldest queued job for the authenticated worker. Returns
+`204` when no work is available.
+
+Successful response:
+
+```json
+{
+  "job": {
+    "id": "665...",
+    "status": "processing",
+    "sourceUrl": "https://api.telegram.org/file/...",
+    "sourceKind": "voice",
+    "fileId": "AwAC...",
+    "attempts": 1
+  }
+}
+```
+
+The Mongo update filters on `status: queued` and sets `status: processing`,
+`workerId`, `claimedAt`, and `heartbeatAt` in one `findOneAndUpdate`, so two
+workers cannot claim the same queued job.
+
+### `GET /jobs/:id`
+
+Returns metadata for a processing job owned by the authenticated worker.
+
+### `GET /jobs/:id/source`
+
+Returns the source audio metadata and URL for a processing job owned by the
+authenticated worker.
+
+### `POST /jobs/:id/heartbeat`
+
+Refreshes `heartbeatAt` for a processing job owned by the authenticated worker.
+
+### `POST /jobs/:id/result`
+
+Completes a processing job owned by the authenticated worker, stores transcript
+data, creates a legacy `Voice` record, and publishes the final transcript unless
+`VOICY_DISABLE_TELEGRAM_PUBLISH=1`.
+
+Request body:
+
+```json
+{
+  "text": "Final transcript",
+  "parts": [{ "timeCode": "00:00", "text": "Final transcript" }],
+  "language": "en",
+  "engine": "faster-whisper",
+  "duration": 3.2,
+  "metadata": { "model": "large-v3" }
+}
+```
+
+### `POST /jobs/:id/failure`
+
+Records worker failure. Retryable failures requeue the job while attempts remain
+below `VOICY_WORKER_MAX_ATTEMPTS` (default `3`); otherwise the job is marked
+`failed`.
+
+Request body:
+
+```json
+{
+  "error": "download timed out",
+  "retryable": true
+}
+```
+
+## Validation
+
+`yarn test:worker-api` runs a scripted HTTP proof against `MONGO`. It verifies:
+
+- missing authentication returns `401`;
+- exactly one of two clients can claim a single queued job;
+- a non-owning client cannot heartbeat another worker's job;
+- result upload completes the job and persists transcript data;
+- retryable failure requeues while attempts remain.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "distribute": "node dist/app.js",
     "develop": "concurrently -k -i -p \"[{name}]\" -n \"Node,TypeScript\" -c \"yellow.bold,cyan.bold\" \"yarn watch-js\" \"yarn watch-ts\"",
     "build-ts": "tsc --skipLibCheck",
+    "test:worker-api": "node scripts/worker-api-proof.js",
+    "worker:create-client": "node scripts/create-worker-client.js",
     "watch-ts": "tsc -w --skipLibCheck",
     "watch-js": "nodemon dist/app.js",
     "audit-locales": "node scripts/audit-localizations.js",

--- a/scripts/create-worker-client.js
+++ b/scripts/create-worker-client.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+require('reflect-metadata')
+require('module-alias/register')
+
+const mongoose = require('mongoose')
+const {
+  WorkerClientModel,
+  generateWorkerToken,
+  hashWorkerToken,
+} = require('../dist/models/WorkerClient')
+
+async function main() {
+  const name = process.argv[2]
+  if (!name) {
+    throw new Error('Usage: yarn worker:create-client <name>')
+  }
+  if (!process.env.MONGO) {
+    throw new Error('MONGO is required')
+  }
+
+  await mongoose.connect(process.env.MONGO)
+  const token = generateWorkerToken()
+  await WorkerClientModel.create({
+    name,
+    tokenHash: hashWorkerToken(token),
+  })
+  console.log(`Worker client created: ${name}`)
+  console.log(`Token: ${token}`)
+  console.log('Store this token now; only its hash was saved.')
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await mongoose.disconnect().catch(() => undefined)
+  })

--- a/scripts/worker-api-proof.js
+++ b/scripts/worker-api-proof.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+process.env.TOKEN = process.env.TOKEN || '000000:test-token'
+process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_dummy'
+process.env.VOICY_DISABLE_TELEGRAM_PUBLISH = '1'
+process.env.WIT_LANGUAGES = process.env.WIT_LANGUAGES || '{"English":"token"}'
+
+require('reflect-metadata')
+require('module-alias/register')
+
+const mongoose = require('mongoose')
+const { webhookApp } = require('../dist/helpers/startWebhook')
+const {
+  WorkerClientModel,
+  hashWorkerToken,
+} = require('../dist/models/WorkerClient')
+const {
+  TranscriptionJobModel,
+  TranscriptionJobSourceKind,
+  TranscriptionJobStatus,
+} = require('../dist/models/TranscriptionJob')
+const { VoiceModel } = require('../dist/models/Voice')
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function listen(app) {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => resolve(server))
+  })
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+}
+
+async function request(baseUrl, path, token, options = {}) {
+  return fetch(`${baseUrl}${path}`, {
+    ...options,
+    headers: {
+      Authorization: token ? `Bearer ${token}` : undefined,
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+  })
+}
+
+async function main() {
+  if (!process.env.MONGO) {
+    throw new Error('MONGO is required for the worker API proof')
+  }
+
+  await mongoose.connect(process.env.MONGO)
+  await Promise.all([
+    WorkerClientModel.deleteMany({ name: /^proof-/ }),
+    TranscriptionJobModel.deleteMany({ chatId: 'proof-chat' }),
+    VoiceModel.deleteMany({ fileId: /^proof-file/ }),
+  ])
+
+  const tokenA = 'proof-token-a'
+  const tokenB = 'proof-token-b'
+  await WorkerClientModel.create([
+    { name: 'proof-a', tokenHash: hashWorkerToken(tokenA) },
+    { name: 'proof-b', tokenHash: hashWorkerToken(tokenB) },
+  ])
+  const queuedJob = await TranscriptionJobModel.create({
+    chatId: 'proof-chat',
+    telegramChatId: '123',
+    sourceMessageId: 10,
+    fileId: 'proof-file-1',
+    sourceKind: TranscriptionJobSourceKind.voice,
+    sourceUrl: 'https://example.invalid/proof.ogg',
+  })
+
+  const server = await listen(webhookApp)
+  const baseUrl = `http://127.0.0.1:${server.address().port}/worker/v1`
+
+  try {
+    const unauthenticated = await request(baseUrl, '/jobs/claim', undefined, {
+      method: 'POST',
+    })
+    assert(unauthenticated.status === 401, 'unauthenticated claim should fail')
+
+    const [claimA, claimB] = await Promise.all([
+      request(baseUrl, '/jobs/claim', tokenA, { method: 'POST' }),
+      request(baseUrl, '/jobs/claim', tokenB, { method: 'POST' }),
+    ])
+    const claimStatuses = [claimA.status, claimB.status].sort().join(',')
+    assert(
+      claimStatuses === '200,204',
+      `only one worker should claim the queued job, got ${claimStatuses}`
+    )
+
+    const claimedResponse = claimA.status === 200 ? claimA : claimB
+    const claimedToken = claimA.status === 200 ? tokenA : tokenB
+    const otherToken = claimA.status === 200 ? tokenB : tokenA
+    const { job } = await claimedResponse.json()
+    assert(job.id === queuedJob._id.toString(), 'claimed unexpected job')
+    assert(job.status === TranscriptionJobStatus.processing, 'job not processing')
+
+    const source = await request(baseUrl, `/jobs/${job.id}/source`, claimedToken)
+    assert(source.status === 200, 'owning worker should read job source')
+
+    const stolenHeartbeat = await request(
+      baseUrl,
+      `/jobs/${job.id}/heartbeat`,
+      otherToken,
+      { method: 'POST' }
+    )
+    assert(stolenHeartbeat.status === 404, 'other worker should not heartbeat')
+
+    const result = await request(baseUrl, `/jobs/${job.id}/result`, claimedToken, {
+      method: 'POST',
+      body: JSON.stringify({
+        text: 'proof transcript',
+        parts: [{ timeCode: '00:00', text: 'proof transcript' }],
+        language: 'en',
+        engine: 'proof-engine',
+        duration: 1.2,
+      }),
+    })
+    assert(result.status === 200, 'owning worker should submit result')
+    const completedJob = await TranscriptionJobModel.findById(job.id)
+    assert(
+      completedJob.status === TranscriptionJobStatus.completed,
+      'result upload should complete job'
+    )
+    assert(completedJob.resultText === 'proof transcript', 'result text missing')
+
+    const retryJob = await TranscriptionJobModel.create({
+      chatId: 'proof-chat',
+      telegramChatId: '123',
+      sourceMessageId: 11,
+      fileId: 'proof-file-2',
+      sourceKind: TranscriptionJobSourceKind.voice,
+      sourceUrl: 'https://example.invalid/proof-2.ogg',
+    })
+    const claimRetry = await request(baseUrl, '/jobs/claim', tokenA, {
+      method: 'POST',
+    })
+    assert(claimRetry.status === 200, 'second job should be claimable')
+    const retryClaim = await claimRetry.json()
+    assert(retryClaim.job.id === retryJob._id.toString(), 'claimed wrong retry job')
+    const failure = await request(
+      baseUrl,
+      `/jobs/${retryClaim.job.id}/failure`,
+      tokenA,
+      { method: 'POST', body: JSON.stringify({ error: 'temporary', retryable: true }) }
+    )
+    assert(failure.status === 200, 'retryable failure should be accepted')
+    const requeuedJob = await TranscriptionJobModel.findById(retryClaim.job.id)
+    assert(
+      requeuedJob.status === TranscriptionJobStatus.queued,
+      'retryable failure should requeue below max attempts'
+    )
+
+    console.log('worker API proof passed')
+  } finally {
+    await close(server)
+    await Promise.all([
+      WorkerClientModel.deleteMany({ name: /^proof-/ }),
+      TranscriptionJobModel.deleteMany({ chatId: 'proof-chat' }),
+      VoiceModel.deleteMany({ fileId: /^proof-file/ }),
+    ])
+    await mongoose.disconnect()
+  }
+}
+
+main().catch(async (error) => {
+  console.error(error)
+  await mongoose.disconnect().catch(() => undefined)
+  process.exit(1)
+})

--- a/src/helpers/startWebhook.ts
+++ b/src/helpers/startWebhook.ts
@@ -1,9 +1,12 @@
 import * as express from 'express'
 import { ChatModel } from '@/models/Chat'
 import { stripe } from '@/helpers/stripe'
+import workerRouter from '@/helpers/workerApi/router'
 
 export const webhookApp = express()
 const endpointSecret = process.env.STRIPE_WEBHOOK_SIGNING_SECRET
+
+webhookApp.use('/worker/v1', workerRouter)
 
 webhookApp.post(
   '/',

--- a/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
+++ b/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
@@ -23,6 +23,23 @@ function transcriptText(job: DocumentType<TranscriptionJob>) {
 async function storeVoiceRecord(job: DocumentType<TranscriptionJob>) {
   await VoiceModel.create({
     url: job.sourceUrl,
+    status: 'completed',
+    chatId: job.chatId,
+    messageId: job.sourceMessageId,
+    ackMessageId: job.statusMessageId,
+    fileId: job.fileId,
+    fileSize: job.fileSize,
+    mimeType: job.mimeType,
+    sourceType: job.sourceKind,
+    requestedBy: job.requestedByUserId
+      ? Number(job.requestedByUserId)
+      : undefined,
+    forwardFromId: job.forwardedFromUserId
+      ? Number(job.forwardedFromUserId)
+      : undefined,
+    forwardSenderName: job.forwardedSenderName,
+    claimedAt: job.claimedAt,
+    completedAt: job.completedAt || new Date(),
     duration: job.duration || 0,
     language: job.recognitionLanguage || job.recognitionLanguageHint || 'auto',
     text: job.resultText || transcriptText(job),
@@ -30,7 +47,6 @@ async function storeVoiceRecord(job: DocumentType<TranscriptionJob>) {
       part.timeCode || '',
       part.text,
     ]),
-    fileId: job.fileId,
     workerEngine: job.workerEngine,
   })
 }

--- a/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
+++ b/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
@@ -1,0 +1,68 @@
+import { DocumentType } from '@typegoose/typegoose'
+import { TranscriptionJob } from '@/models/TranscriptionJob'
+import { VoiceModel } from '@/models/Voice'
+import bot from '@/helpers/bot'
+
+const TELEGRAM_MESSAGE_LIMIT = 4000
+
+function splitText(text: string) {
+  return text.match(new RegExp(`[\\s\\S]{1,${TELEGRAM_MESSAGE_LIMIT}}`, 'g'))
+}
+
+function transcriptText(job: DocumentType<TranscriptionJob>) {
+  if (job.resultParts?.length) {
+    return job.resultParts
+      .map((part) =>
+        part.timeCode ? `${part.timeCode}:\n${part.text}` : part.text
+      )
+      .join('\n')
+  }
+  return job.resultText || ''
+}
+
+async function storeVoiceRecord(job: DocumentType<TranscriptionJob>) {
+  await VoiceModel.create({
+    url: job.sourceUrl,
+    duration: job.duration || 0,
+    language: job.recognitionLanguage || job.recognitionLanguageHint || 'auto',
+    text: job.resultText || transcriptText(job),
+    textWithTimecodes: job.resultParts?.map((part) => [
+      part.timeCode || '',
+      part.text,
+    ]),
+    fileId: job.fileId,
+    workerEngine: job.workerEngine,
+  })
+}
+
+export default async function publishCompletedTranscriptionJob(
+  job: DocumentType<TranscriptionJob>
+) {
+  await storeVoiceRecord(job)
+
+  if (process.env.VOICY_DISABLE_TELEGRAM_PUBLISH === '1') {
+    return
+  }
+
+  const chunks = splitText(transcriptText(job).trim()) || ['']
+  const firstText = chunks.shift() || ''
+  if (job.statusMessageId) {
+    await bot.api.editMessageText(
+      job.telegramChatId,
+      job.statusMessageId,
+      firstText || 'Transcription completed, but no text was detected.'
+    )
+  } else {
+    await bot.api.sendMessage(
+      job.telegramChatId,
+      firstText || 'Transcription completed, but no text was detected.',
+      { reply_to_message_id: job.sourceMessageId }
+    )
+  }
+
+  for (const chunk of chunks) {
+    await bot.api.sendMessage(job.telegramChatId, chunk, {
+      reply_to_message_id: job.sourceMessageId,
+    })
+  }
+}

--- a/src/helpers/workerApi/authenticateWorker.ts
+++ b/src/helpers/workerApi/authenticateWorker.ts
@@ -1,0 +1,50 @@
+import * as express from 'express'
+import { DocumentType } from '@typegoose/typegoose'
+import {
+  WorkerClient,
+  WorkerClientModel,
+  hashWorkerToken,
+} from '@/models/WorkerClient'
+
+export interface WorkerRequest extends express.Request {
+  workerClient?: DocumentType<WorkerClient>
+  params: { [key: string]: string }
+  body?: Record<string, unknown>
+}
+
+function bearerToken(request: express.Request) {
+  const authorization = request.headers.authorization
+  if (!authorization) {
+    return undefined
+  }
+  const [scheme, token] = authorization.split(' ')
+  if (scheme !== 'Bearer' || !token || authorization.split(' ').length !== 2) {
+    return undefined
+  }
+  return token
+}
+
+export default async function authenticateWorker(
+  request: WorkerRequest,
+  response: express.Response,
+  next: express.NextFunction
+) {
+  const token = bearerToken(request)
+  if (!token) {
+    response.status(401).json({ error: 'missing_worker_token' })
+    return
+  }
+
+  const workerClient = await WorkerClientModel.findOneAndUpdate(
+    { tokenHash: hashWorkerToken(token), enabled: true },
+    { $set: { lastSeenAt: new Date() } },
+    { new: true }
+  )
+  if (!workerClient) {
+    response.status(401).json({ error: 'invalid_worker_token' })
+    return
+  }
+
+  request.workerClient = workerClient
+  next()
+}

--- a/src/helpers/workerApi/jobService.ts
+++ b/src/helpers/workerApi/jobService.ts
@@ -1,0 +1,301 @@
+import { DocumentType } from '@typegoose/typegoose'
+import {
+  TranscriptionJob,
+  TranscriptionJobModel,
+  TranscriptionJobStatus,
+  TranscriptionResultPart,
+  WorkerEngineMetadata,
+} from '@/models/TranscriptionJob'
+import { Types } from 'mongoose'
+import { WorkerClient, WorkerClientModel } from '@/models/WorkerClient'
+import publishCompletedTranscriptionJob from '@/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+
+const MAX_RESULT_TEXT_LENGTH = 100000
+const MAX_RESULT_PARTS = 5000
+
+type TimestampedJob = DocumentType<TranscriptionJob> & {
+  createdAt?: Date
+  updatedAt?: Date
+}
+
+export class WorkerApiError extends Error {
+  status: number
+  code: string
+
+  constructor(status: number, code: string) {
+    super(code)
+    this.status = status
+    this.code = code
+  }
+}
+
+function workerId(workerClient: DocumentType<WorkerClient>) {
+  return workerClient._id.toString()
+}
+
+function assertObjectId(id: string) {
+  if (!Types.ObjectId.isValid(id)) {
+    throw new WorkerApiError(400, 'invalid_job_id')
+  }
+}
+
+function truncateError(error: unknown) {
+  const message =
+    typeof error === 'string'
+      ? error
+      : error instanceof Error
+      ? error.message
+      : 'Unknown worker error'
+  return message.slice(0, 2000)
+}
+
+function maxAttempts() {
+  const configured = Number(process.env.VOICY_WORKER_MAX_ATTEMPTS || 3)
+  return Number.isFinite(configured) && configured > 0 ? configured : 3
+}
+
+function validateResultText(text: unknown) {
+  if (typeof text !== 'string' || !text.trim()) {
+    throw new WorkerApiError(400, 'result_text_required')
+  }
+  if (text.length > MAX_RESULT_TEXT_LENGTH) {
+    throw new WorkerApiError(400, 'result_text_too_large')
+  }
+  return text
+}
+
+function validateResultParts(parts: unknown): TranscriptionResultPart[] {
+  if (parts === undefined) {
+    return undefined
+  }
+  if (!Array.isArray(parts) || parts.length > MAX_RESULT_PARTS) {
+    throw new WorkerApiError(400, 'invalid_result_parts')
+  }
+  return parts.map((part) => {
+    if (!part || typeof part !== 'object') {
+      throw new WorkerApiError(400, 'invalid_result_part')
+    }
+    const { timeCode, text } = part as TranscriptionResultPart
+    if (timeCode !== undefined && typeof timeCode !== 'string') {
+      throw new WorkerApiError(400, 'invalid_result_part_timecode')
+    }
+    if (typeof text !== 'string') {
+      throw new WorkerApiError(400, 'invalid_result_part_text')
+    }
+    return { timeCode, text }
+  })
+}
+
+function validateOptionalString(value: unknown, code: string) {
+  if (value === undefined) {
+    return undefined
+  }
+  if (typeof value !== 'string') {
+    throw new WorkerApiError(400, code)
+  }
+  return value
+}
+
+function validateDuration(value: unknown) {
+  if (value === undefined) {
+    return undefined
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new WorkerApiError(400, 'invalid_duration')
+  }
+  return value
+}
+
+function validateEngineMetadata(value: unknown): WorkerEngineMetadata {
+  if (value === undefined) {
+    return undefined
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new WorkerApiError(400, 'invalid_engine_metadata')
+  }
+  return value as WorkerEngineMetadata
+}
+
+export function serializeJob(job: DocumentType<TranscriptionJob>) {
+  const timestampedJob = job as TimestampedJob
+  return {
+    id: job._id.toString(),
+    status: job.status,
+    chatId: job.chatId,
+    telegramChatId: job.telegramChatId,
+    sourceMessageId: job.sourceMessageId,
+    statusMessageId: job.statusMessageId,
+    requestMessageId: job.requestMessageId,
+    fileId: job.fileId,
+    fileUniqueId: job.fileUniqueId,
+    filePath: job.filePath,
+    fileSize: job.fileSize,
+    mimeType: job.mimeType,
+    sourceKind: job.sourceKind,
+    sourceUrl: job.sourceUrl,
+    requestedByUserId: job.requestedByUserId,
+    forwardedFromUserId: job.forwardedFromUserId,
+    forwardedSenderName: job.forwardedSenderName,
+    recognitionLanguageHint: job.recognitionLanguageHint,
+    attempts: job.attempts,
+    claimedAt: job.claimedAt,
+    heartbeatAt: job.heartbeatAt,
+    createdAt: timestampedJob.createdAt,
+    updatedAt: timestampedJob.updatedAt,
+  }
+}
+
+export async function claimNextJob(workerClient: DocumentType<WorkerClient>) {
+  const now = new Date()
+  const job = await TranscriptionJobModel.findOneAndUpdate(
+    { status: TranscriptionJobStatus.queued },
+    {
+      $set: {
+        status: TranscriptionJobStatus.processing,
+        workerId: workerId(workerClient),
+        claimedAt: now,
+        heartbeatAt: now,
+      },
+      $inc: { attempts: 1 },
+    },
+    { sort: { createdAt: 1 }, new: true }
+  )
+
+  if (job) {
+    await WorkerClientModel.updateOne(
+      { _id: workerClient._id },
+      { $set: { lastClaimedAt: now } }
+    )
+  }
+
+  return job
+}
+
+export async function getOwnedJob(
+  jobId: string,
+  workerClient: DocumentType<WorkerClient>
+) {
+  assertObjectId(jobId)
+  const job = await TranscriptionJobModel.findOne({
+    _id: jobId,
+    workerId: workerId(workerClient),
+    status: TranscriptionJobStatus.processing,
+  })
+  if (!job) {
+    throw new WorkerApiError(404, 'job_not_found')
+  }
+  return job
+}
+
+export async function heartbeatJob(
+  jobId: string,
+  workerClient: DocumentType<WorkerClient>
+) {
+  assertObjectId(jobId)
+  const job = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      _id: jobId,
+      workerId: workerId(workerClient),
+      status: TranscriptionJobStatus.processing,
+    },
+    { $set: { heartbeatAt: new Date() } },
+    { new: true }
+  )
+  if (!job) {
+    throw new WorkerApiError(404, 'job_not_found')
+  }
+  return job
+}
+
+export async function completeJob(
+  jobId: string,
+  workerClient: DocumentType<WorkerClient>,
+  body: Record<string, unknown>
+) {
+  assertObjectId(jobId)
+  const resultText = validateResultText(body.text)
+  const resultParts = validateResultParts(body.parts)
+  const recognitionLanguage = validateOptionalString(
+    body.language,
+    'invalid_language'
+  )
+  const workerEngine = validateOptionalString(body.engine, 'invalid_engine')
+  const duration = validateDuration(body.duration)
+  const workerEngineMetadata = validateEngineMetadata(body.metadata)
+  const now = new Date()
+  const job = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      _id: jobId,
+      workerId: workerId(workerClient),
+      status: TranscriptionJobStatus.processing,
+    },
+    {
+      $set: {
+        status: TranscriptionJobStatus.completed,
+        resultText,
+        resultParts,
+        recognitionLanguage,
+        workerEngine,
+        duration,
+        workerEngineMetadata,
+        heartbeatAt: now,
+        completedAt: now,
+      },
+      $unset: { lastError: '' },
+    },
+    { new: true }
+  )
+  if (!job) {
+    throw new WorkerApiError(404, 'job_not_found')
+  }
+
+  try {
+    await publishCompletedTranscriptionJob(job)
+  } catch (error) {
+    console.error('Failed to publish completed transcription job', error)
+  }
+  return job
+}
+
+export async function failJob(
+  jobId: string,
+  workerClient: DocumentType<WorkerClient>,
+  body: Record<string, unknown>
+) {
+  assertObjectId(jobId)
+  const retryable =
+    body.retryable === undefined ? true : Boolean(body.retryable)
+  const now = new Date()
+  const currentJob = await getOwnedJob(jobId, workerClient)
+  const shouldRetry = retryable && currentJob.attempts < maxAttempts()
+  const update = shouldRetry
+    ? {
+        $set: {
+          status: TranscriptionJobStatus.queued,
+          lastError: truncateError(body.error),
+        },
+        $unset: { workerId: '', claimedAt: '', heartbeatAt: '' },
+      }
+    : {
+        $set: {
+          status: TranscriptionJobStatus.failed,
+          lastError: truncateError(body.error),
+          heartbeatAt: now,
+          failedAt: now,
+        },
+      }
+
+  const job = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      _id: jobId,
+      workerId: workerId(workerClient),
+      status: TranscriptionJobStatus.processing,
+    },
+    update,
+    { new: true }
+  )
+  if (!job) {
+    throw new WorkerApiError(404, 'job_not_found')
+  }
+  return job
+}

--- a/src/helpers/workerApi/router.ts
+++ b/src/helpers/workerApi/router.ts
@@ -1,0 +1,110 @@
+import * as express from 'express'
+import {
+  WorkerApiError,
+  claimNextJob,
+  completeJob,
+  failJob,
+  getOwnedJob,
+  heartbeatJob,
+  serializeJob,
+} from '@/helpers/workerApi/jobService'
+import authenticateWorker, {
+  WorkerRequest,
+} from '@/helpers/workerApi/authenticateWorker'
+
+const workerRouter = express.Router()
+
+function asyncRoute(
+  handler: (request: WorkerRequest, response: express.Response) => Promise<void>
+) {
+  return (request: WorkerRequest, response: express.Response) => {
+    handler(request, response).catch((error) => {
+      if (error instanceof WorkerApiError) {
+        response.status(error.status).json({ error: error.code })
+        return
+      }
+      console.error(error)
+      response.status(500).json({ error: 'worker_api_error' })
+    })
+  }
+}
+
+function workerClient(request: WorkerRequest) {
+  return request.workerClient
+}
+
+workerRouter.use(express.json({ limit: '1mb' }))
+workerRouter.use(authenticateWorker)
+
+workerRouter.post(
+  '/jobs/claim',
+  asyncRoute(async (request, response) => {
+    const job = await claimNextJob(workerClient(request))
+    if (!job) {
+      response.status(204).send()
+      return
+    }
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+workerRouter.get(
+  '/jobs/:id',
+  asyncRoute(async (request, response) => {
+    const job = await getOwnedJob(request.params.id, workerClient(request))
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+workerRouter.get(
+  '/jobs/:id/source',
+  asyncRoute(async (request, response) => {
+    const job = await getOwnedJob(request.params.id, workerClient(request))
+    response.json({
+      source: {
+        jobId: job._id.toString(),
+        fileId: job.fileId,
+        fileUniqueId: job.fileUniqueId,
+        filePath: job.filePath,
+        fileSize: job.fileSize,
+        mimeType: job.mimeType,
+        sourceKind: job.sourceKind,
+        sourceUrl: job.sourceUrl,
+      },
+    })
+  })
+)
+
+workerRouter.post(
+  '/jobs/:id/heartbeat',
+  asyncRoute(async (request, response) => {
+    const job = await heartbeatJob(request.params.id, workerClient(request))
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+workerRouter.post(
+  '/jobs/:id/result',
+  asyncRoute(async (request, response) => {
+    const job = await completeJob(
+      request.params.id,
+      workerClient(request),
+      request.body || {}
+    )
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+workerRouter.post(
+  '/jobs/:id/failure',
+  asyncRoute(async (request, response) => {
+    const job = await failJob(
+      request.params.id,
+      workerClient(request),
+      request.body || {}
+    )
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+export default workerRouter

--- a/src/models/TranscriptionJob.ts
+++ b/src/models/TranscriptionJob.ts
@@ -1,0 +1,113 @@
+import { Schema } from 'mongoose'
+import {
+  Severity,
+  getModelForClass,
+  index,
+  modelOptions,
+  prop,
+} from '@typegoose/typegoose'
+
+export enum TranscriptionJobStatus {
+  queued = 'queued',
+  processing = 'processing',
+  completed = 'completed',
+  failed = 'failed',
+}
+
+export enum TranscriptionJobSourceKind {
+  voice = 'voice',
+  videoNote = 'video_note',
+  audio = 'audio',
+  document = 'document',
+}
+
+export interface TranscriptionResultPart {
+  timeCode?: string
+  text: string
+}
+
+export interface WorkerEngineMetadata {
+  engine?: string
+  model?: string
+  language?: string
+  duration?: number
+}
+
+@index({ status: 1, createdAt: 1 })
+@index({ workerId: 1, status: 1 })
+@index({ chatId: 1, sourceMessageId: 1 })
+@modelOptions({
+  schemaOptions: { timestamps: true },
+  options: { allowMixed: Severity.ALLOW },
+})
+export class TranscriptionJob {
+  @prop({
+    required: true,
+    enum: TranscriptionJobStatus,
+    default: TranscriptionJobStatus.queued,
+    index: true,
+  })
+  status: TranscriptionJobStatus
+  @prop({ required: true, index: true })
+  chatId: string
+  @prop({ required: true })
+  telegramChatId: string
+  @prop({ required: true })
+  sourceMessageId: number
+  @prop()
+  statusMessageId?: number
+  @prop()
+  requestMessageId?: number
+  @prop({ required: true })
+  fileId: string
+  @prop()
+  fileUniqueId?: string
+  @prop()
+  filePath?: string
+  @prop()
+  fileSize?: number
+  @prop()
+  mimeType?: string
+  @prop({ required: true, enum: TranscriptionJobSourceKind })
+  sourceKind: TranscriptionJobSourceKind
+  @prop({ required: true })
+  sourceUrl: string
+  @prop()
+  requestedByUserId?: string
+  @prop()
+  forwardedFromUserId?: string
+  @prop()
+  forwardedSenderName?: string
+  @prop()
+  uiLocale?: string
+  @prop()
+  recognitionLanguageHint?: string
+  @prop({ index: true })
+  workerId?: string
+  @prop()
+  claimedAt?: Date
+  @prop()
+  heartbeatAt?: Date
+  @prop({ required: true, default: 0 })
+  attempts: number
+  @prop()
+  lastError?: string
+  @prop()
+  resultText?: string
+  @prop({ type: Schema.Types.Mixed })
+  resultParts?: TranscriptionResultPart[]
+  @prop()
+  recognitionLanguage?: string
+  @prop()
+  workerEngine?: string
+  @prop({ type: Schema.Types.Mixed })
+  workerEngineMetadata?: WorkerEngineMetadata
+  @prop()
+  duration?: number
+  @prop()
+  completedAt?: Date
+  @prop()
+  failedAt?: Date
+}
+
+export const TranscriptionJobModel = getModelForClass(TranscriptionJob)

--- a/src/models/Voice.ts
+++ b/src/models/Voice.ts
@@ -60,6 +60,10 @@ export class Voice {
   textWithTimecodes?: string[][]
   @prop()
   file?: string
+  @prop()
+  fileId?: string
+  @prop()
+  workerEngine?: string
 }
 
 export const VoiceModel = getModelForClass(Voice)

--- a/src/models/Voice.ts
+++ b/src/models/Voice.ts
@@ -61,8 +61,6 @@ export class Voice {
   @prop()
   file?: string
   @prop()
-  fileId?: string
-  @prop()
   workerEngine?: string
 }
 

--- a/src/models/WorkerClient.ts
+++ b/src/models/WorkerClient.ts
@@ -1,0 +1,46 @@
+import * as crypto from 'crypto'
+import { Schema } from 'mongoose'
+import {
+  Severity,
+  getModelForClass,
+  index,
+  modelOptions,
+  prop,
+} from '@typegoose/typegoose'
+
+export interface WorkerClientCapabilities {
+  engine?: string
+  platform?: string
+  languages?: string[]
+  gpu?: string
+}
+
+@index({ tokenHash: 1 }, { unique: true })
+@modelOptions({
+  schemaOptions: { timestamps: true },
+  options: { allowMixed: Severity.ALLOW },
+})
+export class WorkerClient {
+  @prop({ required: true, unique: true, index: true })
+  name: string
+  @prop({ required: true, unique: true, index: true })
+  tokenHash: string
+  @prop({ required: true, default: true, index: true })
+  enabled: boolean
+  @prop()
+  lastSeenAt?: Date
+  @prop()
+  lastClaimedAt?: Date
+  @prop({ type: Schema.Types.Mixed })
+  capabilities?: WorkerClientCapabilities
+}
+
+export const WorkerClientModel = getModelForClass(WorkerClient)
+
+export function hashWorkerToken(token: string) {
+  return crypto.createHash('sha256').update(token).digest('hex')
+}
+
+export function generateWorkerToken() {
+  return `voicy_worker_${crypto.randomBytes(32).toString('base64url')}`
+}


### PR DESCRIPTION
## Summary
- add WorkerClient and TranscriptionJob models with hashed worker-token auth and durable job state
- mount /worker/v1 API routes for claim, source metadata, heartbeat, result upload, and failure/retry handling
- publish completed transcripts into the existing Voice history path and Telegram delivery path, with publication isolated from worker result acceptance
- add worker token provisioning/API docs and a Mongo-backed scripted API proof

## Validation
- COREPACK_ENABLE_AUTO_PIN=0 yarn build-ts
- COREPACK_ENABLE_AUTO_PIN=0 yarn lint
- docker run --rm -d --name voicy-worker-api-proof-mongo -p 27018:27017 mongo:6
- MONGO='mongodb://127.0.0.1:27018/voicy-worker-api-proof' COREPACK_ENABLE_AUTO_PIN=0 yarn test:worker-api
