### PR TITLE
Add live transcription progress updates

### DIFF
--- a/docs/worker-api.md
+++ b/docs/worker-api.md
@@ -51,11 +51,38 @@ authenticated worker.
 
 Refreshes `heartbeatAt` for a processing job owned by the authenticated worker.
 
+### `POST /jobs/:id/progress`
+
+Stores a partial transcript for a processing job owned by the authenticated
+worker and edits the bot's in-chat status message when enough time has passed
+since the last visible progress edit.
+
+Request body:
+
+```json
+{
+  "text": "Partial transcript produced so far",
+  "parts": [{ "timeCode": "00:00", "text": "Partial transcript" }],
+  "language": "en",
+  "engine": "faster-whisper",
+  "duration": 1.4,
+  "metadata": { "model": "large-v3" }
+}
+```
+
+Workers should call this endpoint only for meaningful transcript changes. The
+server throttles visible Telegram edits with `VOICY_PROGRESS_EDIT_INTERVAL_MS`
+(default `2500`, minimum `1000`) and stores every accepted progress payload even
+when an edit is skipped. If a job has no editable status message, progress is
+still stored and the final result will be sent as a normal reply.
+
 ### `POST /jobs/:id/result`
 
 Completes a processing job owned by the authenticated worker, stores transcript
-data, creates a legacy `Voice` record, and publishes the final transcript unless
-`VOICY_DISABLE_TELEGRAM_PUBLISH=1`.
+data, creates a legacy `Voice` record, and publishes the final transcript by
+editing the status/progress message unless `VOICY_DISABLE_TELEGRAM_PUBLISH=1`.
+Long final transcripts are split into follow-up replies after the first edited
+message.
 
 Request body:
 
@@ -92,5 +119,6 @@ Request body:
 - missing authentication returns `401`;
 - exactly one of two clients can claim a single queued job;
 - a non-owning client cannot heartbeat another worker's job;
+- progress upload stores partial transcript state for the owning worker;
 - result upload completes the job and persists transcript data;
 - retryable failure requeues while attempts remain.

--- a/scripts/worker-api-proof.js
+++ b/scripts/worker-api-proof.js
@@ -114,6 +114,29 @@ async function main() {
     )
     assert(stolenHeartbeat.status === 404, 'other worker should not heartbeat')
 
+    const progress = await request(
+      baseUrl,
+      `/jobs/${job.id}/progress`,
+      claimedToken,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          text: 'proof partial transcript',
+          parts: [{ timeCode: '00:00', text: 'proof partial transcript' }],
+          language: 'en',
+          engine: 'proof-engine',
+          duration: 0.6,
+        }),
+      }
+    )
+    assert(progress.status === 200, 'owning worker should submit progress')
+    const progressedJob = await TranscriptionJobModel.findById(job.id)
+    assert(
+      progressedJob.partialResultText === 'proof partial transcript',
+      'progress text missing'
+    )
+    assert(progressedJob.lastProgressAt, 'progress timestamp missing')
+
     const result = await request(baseUrl, `/jobs/${job.id}/result`, claimedToken, {
       method: 'POST',
       body: JSON.stringify({

--- a/src/commands/handleTranscribe.ts
+++ b/src/commands/handleTranscribe.ts
@@ -46,7 +46,13 @@ export default async function handleTranscribe(ctx: Context) {
     const fileData = await ctx.api.getFile(voice.file_id)
     const voiceUrl = fileUrl(fileData.file_path)
 
-    await enqueueTranscription(ctx, voiceUrl, voice.file_id, message)
+    await enqueueTranscription(
+      ctx,
+      voiceUrl,
+      voice.file_id,
+      message,
+      fileData.file_path
+    )
   } catch (error) {
     report(error, { ctx, location: 'handleTranscribe' })
     await ctx.reply(ctx.i18n.t('error_queue'), {

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -1,5 +1,9 @@
 import { Message } from '@grammyjs/types'
-import { addQueuedVoice } from '@/models/Voice'
+import {
+  TranscriptionJobModel,
+  TranscriptionJobSourceKind,
+  TranscriptionJobStatus,
+} from '@/models/TranscriptionJob'
 import Context from '@/models/Context'
 import fileUrl from '@/helpers/fileUrl'
 import report from '@/helpers/report'
@@ -9,6 +13,7 @@ type AudioPayload = {
   file_size?: number
   mime_type?: string
   file_name?: string
+  file_unique_id?: string
   sourceType: 'voice' | 'audio' | 'document' | 'video_note'
 }
 
@@ -41,7 +46,13 @@ export default async function handleAudio(ctx: Context) {
 
     const fileData = await ctx.getFile()
     const voiceUrl = fileUrl(fileData.file_path)
-    await enqueueTranscription(ctx, voiceUrl, audio.file_id, message)
+    await enqueueTranscription(
+      ctx,
+      voiceUrl,
+      audio.file_id,
+      message,
+      fileData.file_path
+    )
   } catch (error) {
     report(error, { ctx, location: 'handleMessage' })
     await sendQueueError(ctx)
@@ -59,21 +70,29 @@ async function enqueueTranscription(
   ctx: Context,
   url: string,
   fileId: string,
-  sourceMessage: Message = ctx.msg
+  sourceMessage: Message = ctx.msg,
+  filePath?: string
 ) {
   const audio = audioFromMessage(sourceMessage)
-  const queuedVoice = await addQueuedVoice({
-    url,
-    chat: ctx.dbchat,
-    messageId: sourceMessage.message_id,
+  const queuedJob = await TranscriptionJobModel.create({
+    status: TranscriptionJobStatus.queued,
+    chatId: ctx.dbchat.id,
+    telegramChatId: String(ctx.chat.id),
+    sourceMessageId: sourceMessage.message_id,
+    requestMessageId: ctx.msg?.message_id,
     fileId,
+    filePath,
     fileSize: audio.file_size,
     mimeType: audio.mime_type,
-    fileName: audio.file_name,
-    sourceType: audio.sourceType,
-    requestedBy: ctx.from?.id,
-    forwardFromId: sourceMessage.forward_from?.id,
+    fileUniqueId: fileUniqueId(audio),
+    sourceKind: sourceKind(audio.sourceType),
+    sourceUrl: url,
+    requestedByUserId: ctx.from?.id ? String(ctx.from.id) : undefined,
+    forwardedFromUserId: sourceMessage.forward_from?.id
+      ? String(sourceMessage.forward_from.id)
+      : undefined,
     forwardSenderName: sourceMessage.forward_sender_name,
+    uiLocale: ctx.dbchat.uiLanguage,
   })
 
   try {
@@ -81,8 +100,8 @@ async function enqueueTranscription(
       reply_to_message_id: sourceMessage.message_id,
       parse_mode: 'Markdown',
     })
-    queuedVoice.ackMessageId = ackMessage.message_id
-    await queuedVoice.save()
+    queuedJob.statusMessageId = ackMessage.message_id
+    await queuedJob.save()
   } catch (error) {
     report(error, { ctx, location: 'ackQueuedTranscription' })
   }
@@ -92,7 +111,18 @@ async function enqueueTranscription(
       (new Date().getTime() - ctx.timeReceived.getTime()) / 1000
     }s`
   )
-  return queuedVoice
+  return queuedJob
+}
+
+function sourceKind(sourceType: AudioPayload['sourceType']) {
+  if (sourceType === 'video_note') {
+    return TranscriptionJobSourceKind.videoNote
+  }
+  return sourceType as TranscriptionJobSourceKind
+}
+
+function fileUniqueId(audio: AudioPayload) {
+  return 'file_unique_id' in audio ? audio.file_unique_id : undefined
 }
 
 function audioFromMessage(message: Message): AudioPayload {

--- a/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
+++ b/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
@@ -1,24 +1,11 @@
 import { DocumentType } from '@typegoose/typegoose'
 import { TranscriptionJob } from '@/models/TranscriptionJob'
 import { VoiceModel } from '@/models/Voice'
+import {
+  splitTelegramText,
+  transcriptText,
+} from '@/helpers/transcriptionJobs/transcriptFormatting'
 import bot from '@/helpers/bot'
-
-const TELEGRAM_MESSAGE_LIMIT = 4000
-
-function splitText(text: string) {
-  return text.match(new RegExp(`[\\s\\S]{1,${TELEGRAM_MESSAGE_LIMIT}}`, 'g'))
-}
-
-function transcriptText(job: DocumentType<TranscriptionJob>) {
-  if (job.resultParts?.length) {
-    return job.resultParts
-      .map((part) =>
-        part.timeCode ? `${part.timeCode}:\n${part.text}` : part.text
-      )
-      .join('\n')
-  }
-  return job.resultText || ''
-}
 
 async function storeVoiceRecord(job: DocumentType<TranscriptionJob>) {
   await VoiceModel.create({
@@ -60,7 +47,7 @@ export default async function publishCompletedTranscriptionJob(
     return
   }
 
-  const chunks = splitText(transcriptText(job).trim()) || ['']
+  const chunks = splitTelegramText(transcriptText(job).trim()) || ['']
   const firstText = chunks.shift() || ''
   if (job.statusMessageId) {
     await bot.api.editMessageText(

--- a/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
+++ b/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
@@ -1,0 +1,79 @@
+import { DocumentType } from '@typegoose/typegoose'
+import { TranscriptionJob } from '@/models/TranscriptionJob'
+import {
+  partialTranscriptText,
+  progressPreview,
+} from '@/helpers/transcriptionJobs/transcriptFormatting'
+import bot from '@/helpers/bot'
+
+const DEFAULT_PROGRESS_EDIT_INTERVAL_MS = 2500
+
+type ProgressPhase = 'processing' | 'partial' | 'retrying' | 'failed'
+
+function progressEditIntervalMs() {
+  const configured = Number(process.env.VOICY_PROGRESS_EDIT_INTERVAL_MS)
+  return Number.isFinite(configured) && configured >= 1000
+    ? configured
+    : DEFAULT_PROGRESS_EDIT_INTERVAL_MS
+}
+
+function shouldThrottle(job: DocumentType<TranscriptionJob>, force: boolean) {
+  if (force || !job.lastProgressPublishedAt) {
+    return false
+  }
+  return (
+    new Date().getTime() - job.lastProgressPublishedAt.getTime() <
+    progressEditIntervalMs()
+  )
+}
+
+function statusText(phase: ProgressPhase, job: DocumentType<TranscriptionJob>) {
+  if (phase === 'processing') {
+    return 'Transcription started...'
+  }
+  if (phase === 'retrying') {
+    return 'Transcription failed; retrying...'
+  }
+  if (phase === 'failed') {
+    return 'Transcription failed. Please try again later.'
+  }
+  const partialText = partialTranscriptText(job)
+  return partialText ? progressPreview(partialText) : 'Transcribing...'
+}
+
+export default async function publishTranscriptionJobProgress(
+  job: DocumentType<TranscriptionJob>,
+  phase: ProgressPhase,
+  { force = false }: { force?: boolean } = {}
+) {
+  if (
+    process.env.VOICY_DISABLE_TELEGRAM_PUBLISH === '1' ||
+    !job.statusMessageId ||
+    shouldThrottle(job, force)
+  ) {
+    return false
+  }
+
+  try {
+    await bot.api.editMessageText(
+      job.telegramChatId,
+      job.statusMessageId,
+      statusText(phase, job)
+    )
+  } catch (error) {
+    const description =
+      error && typeof error === 'object' && 'description' in error
+        ? String((error as { description?: string }).description)
+        : ''
+    if (!description.includes('message is not modified')) {
+      throw error
+    }
+  }
+
+  if (phase === 'partial') {
+    job.lastProgressPublishedAt = new Date()
+    await job.save()
+  }
+
+  return true
+}

--- a/src/helpers/transcriptionJobs/transcriptFormatting.ts
+++ b/src/helpers/transcriptionJobs/transcriptFormatting.ts
@@ -1,0 +1,50 @@
+import { DocumentType } from '@typegoose/typegoose'
+import {
+  TranscriptionJob,
+  TranscriptionResultPart,
+} from '@/models/TranscriptionJob'
+
+export const TELEGRAM_MESSAGE_LIMIT = 4000
+
+const PROGRESS_HEADER = 'Transcribing...'
+const PROGRESS_FOOTER = 'Partial transcript; final text may still change.'
+
+export function splitTelegramText(text: string) {
+  return text.match(new RegExp(`[\\s\\S]{1,${TELEGRAM_MESSAGE_LIMIT}}`, 'g'))
+}
+
+export function transcriptTextFromParts(
+  parts?: TranscriptionResultPart[],
+  fallback = ''
+) {
+  if (parts?.length) {
+    return parts
+      .map((part) =>
+        part.timeCode ? `${part.timeCode}:\n${part.text}` : part.text
+      )
+      .join('\n')
+  }
+  return fallback
+}
+
+export function transcriptText(job: DocumentType<TranscriptionJob>) {
+  return transcriptTextFromParts(job.resultParts, job.resultText || '')
+}
+
+export function partialTranscriptText(job: DocumentType<TranscriptionJob>) {
+  return transcriptTextFromParts(
+    job.partialResultParts,
+    job.partialResultText || job.resultText || ''
+  )
+}
+
+export function progressPreview(text: string) {
+  const reserved = PROGRESS_HEADER.length + PROGRESS_FOOTER.length + 8
+  const limit = TELEGRAM_MESSAGE_LIMIT - reserved
+  const normalized = text.trim()
+  const preview =
+    normalized.length > limit
+      ? `${normalized.slice(0, limit - 3)}...`
+      : normalized
+  return `${PROGRESS_HEADER}\n\n${preview}\n\n${PROGRESS_FOOTER}`
+}

--- a/src/helpers/workerApi/jobService.ts
+++ b/src/helpers/workerApi/jobService.ts
@@ -9,6 +9,7 @@ import {
 import { Types } from 'mongoose'
 import { WorkerClient, WorkerClientModel } from '@/models/WorkerClient'
 import publishCompletedTranscriptionJob from '@/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+import publishTranscriptionJobProgress from '@/helpers/transcriptionJobs/publishTranscriptionJobProgress'
 
 const MAX_RESULT_TEXT_LENGTH = 100000
 const MAX_RESULT_PARTS = 5000
@@ -60,6 +61,19 @@ function validateResultText(text: unknown) {
   }
   if (text.length > MAX_RESULT_TEXT_LENGTH) {
     throw new WorkerApiError(400, 'result_text_too_large')
+  }
+  return text
+}
+
+function validateProgressText(text: unknown) {
+  if (text === undefined) {
+    return undefined
+  }
+  if (typeof text !== 'string') {
+    throw new WorkerApiError(400, 'invalid_progress_text')
+  }
+  if (text.length > MAX_RESULT_TEXT_LENGTH) {
+    throw new WorkerApiError(400, 'progress_text_too_large')
   }
   return text
 }
@@ -137,6 +151,9 @@ export function serializeJob(job: DocumentType<TranscriptionJob>) {
     forwardedFromUserId: job.forwardedFromUserId,
     forwardedSenderName: job.forwardedSenderName,
     recognitionLanguageHint: job.recognitionLanguageHint,
+    partialResultText: job.partialResultText,
+    lastProgressAt: job.lastProgressAt,
+    lastProgressPublishedAt: job.lastProgressPublishedAt,
     attempts: job.attempts,
     claimedAt: job.claimedAt,
     heartbeatAt: job.heartbeatAt,
@@ -165,6 +182,9 @@ export async function claimNextJob(workerClient: DocumentType<WorkerClient>) {
     await WorkerClientModel.updateOne(
       { _id: workerClient._id },
       { $set: { lastClaimedAt: now } }
+    )
+    publishTranscriptionJobProgress(job, 'processing').catch((error) =>
+      console.error('Failed to publish transcription job start', error)
     )
   }
 
@@ -203,6 +223,57 @@ export async function heartbeatJob(
   )
   if (!job) {
     throw new WorkerApiError(404, 'job_not_found')
+  }
+  return job
+}
+
+export async function updateJobProgress(
+  jobId: string,
+  workerClient: DocumentType<WorkerClient>,
+  body: Record<string, unknown>
+) {
+  assertObjectId(jobId)
+  const partialResultText = validateProgressText(body.text)
+  const partialResultParts = validateResultParts(body.parts)
+  if (!partialResultText?.trim() && !partialResultParts?.length) {
+    throw new WorkerApiError(400, 'progress_text_required')
+  }
+  const recognitionLanguage = validateOptionalString(
+    body.language,
+    'invalid_language'
+  )
+  const workerEngine = validateOptionalString(body.engine, 'invalid_engine')
+  const duration = validateDuration(body.duration)
+  const workerEngineMetadata = validateEngineMetadata(body.metadata)
+  const now = new Date()
+  const job = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      _id: jobId,
+      workerId: workerId(workerClient),
+      status: TranscriptionJobStatus.processing,
+    },
+    {
+      $set: {
+        partialResultText,
+        partialResultParts,
+        recognitionLanguage,
+        workerEngine,
+        duration,
+        workerEngineMetadata,
+        heartbeatAt: now,
+        lastProgressAt: now,
+      },
+    },
+    { new: true }
+  )
+  if (!job) {
+    throw new WorkerApiError(404, 'job_not_found')
+  }
+
+  try {
+    await publishTranscriptionJobProgress(job, 'partial')
+  } catch (error) {
+    console.error('Failed to publish transcription job progress', error)
   }
   return job
 }
@@ -297,5 +368,10 @@ export async function failJob(
   if (!job) {
     throw new WorkerApiError(404, 'job_not_found')
   }
+  publishTranscriptionJobProgress(job, shouldRetry ? 'retrying' : 'failed', {
+    force: true,
+  }).catch((error) =>
+    console.error('Failed to publish transcription job failure', error)
+  )
   return job
 }

--- a/src/helpers/workerApi/router.ts
+++ b/src/helpers/workerApi/router.ts
@@ -7,6 +7,7 @@ import {
   getOwnedJob,
   heartbeatJob,
   serializeJob,
+  updateJobProgress,
 } from '@/helpers/workerApi/jobService'
 import authenticateWorker, {
   WorkerRequest,
@@ -79,6 +80,18 @@ workerRouter.post(
   '/jobs/:id/heartbeat',
   asyncRoute(async (request, response) => {
     const job = await heartbeatJob(request.params.id, workerClient(request))
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+workerRouter.post(
+  '/jobs/:id/progress',
+  asyncRoute(async (request, response) => {
+    const job = await updateJobProgress(
+      request.params.id,
+      workerClient(request),
+      request.body || {}
+    )
     response.json({ job: serializeJob(job) })
   })
 )

--- a/src/models/TranscriptionJob.ts
+++ b/src/models/TranscriptionJob.ts
@@ -97,6 +97,14 @@ export class TranscriptionJob {
   @prop({ type: Schema.Types.Mixed })
   resultParts?: TranscriptionResultPart[]
   @prop()
+  partialResultText?: string
+  @prop({ type: Schema.Types.Mixed })
+  partialResultParts?: TranscriptionResultPart[]
+  @prop()
+  lastProgressAt?: Date
+  @prop()
+  lastProgressPublishedAt?: Date
+  @prop()
   recognitionLanguage?: string
   @prop()
   workerEngine?: string


### PR DESCRIPTION
## Summary
- enqueue incoming audio as worker transcription jobs with editable status message ids
- add worker progress endpoint for partial transcripts and throttled Telegram message edits
- keep final transcript publishing distinct from partial progress and document rate-limit/fallback behavior

## Validation
- yarn lint
- ./node_modules/.bin/tsc --skipLibCheck

## Manual QA
Use Telegram with a worker that calls POST /worker/v1/jobs/:id/progress while processing. Send a voice/audio message, confirm the queued message edits to started/partial progress, confirm the final transcript replaces the partial status, and confirm final-only workers still replace the queued message with the final transcript.