### PR TITLE
Add Voicy vNext QA proof checklist

### DIFF
--- a/docs/voicy-vnext-qa.md
+++ b/docs/voicy-vnext-qa.md
@@ -1,0 +1,88 @@
+# Voicy vNext QA Checklist
+
+Use a feature branch or PR build for this checklist. Do not run this QA against
+`main` unless the branch has already been merged and the release itself is being
+verified.
+
+## Automated Proofs
+
+Run these from the repo root:
+
+```sh
+yarn install --frozen-lockfile
+yarn build-ts
+yarn lint
+MONGO=mongodb://127.0.0.1:27017/voicy_kaneo_7_worker_api yarn test:worker-api
+yarn test:worker-client
+MONGO=mongodb://127.0.0.1:27017/voicy_kaneo_7_worker_e2e yarn test:worker-e2e
+MONGO=mongodb://127.0.0.1:27017/voicy_kaneo_7_qa yarn test:qa-vnext
+```
+
+`test:qa-vnext` downloads a real public WAV speech sample from the
+free-spoken-digit-dataset, serves it as a queued Telegram voice source, runs the
+worker client against the local worker API, and verifies the completed
+`TranscriptionJob` plus legacy `Voice` record.
+
+## Private Chat
+
+Environment:
+
+- Telegram Web or desktop Telegram already logged in on this Mac.
+- Local or PR Voicy bot running with a test bot token.
+- Mongo available to inspect `chats`, `transcriptionjobs`, and `voices`.
+- A worker token created with `yarn worker:create-client`.
+- A worker running with `VOICY_WORKER_IDLE_EXIT=1` for each sample message.
+
+Path:
+
+1. Open the test bot in a private chat.
+2. Send `/start`.
+3. Send `/help`.
+4. Send `/donate` from an unpaid chat.
+5. Send a short voice message while unpaid.
+6. Mark the test chat paid in Mongo, then send the same voice message again.
+7. Run the worker against the local or PR backend.
+
+Expected result:
+
+- `/start` and `/help` explain queued transcription and mention
+  `@voicy_legacy_bot`.
+- `/donate` and the unpaid voice-message response frame payment as funding
+  transcription compute.
+- The paid voice message creates one queued `TranscriptionJob`.
+- Telegram shows the queued acknowledgement.
+- Worker claim changes the job to `processing`.
+- Progress edits are visible only if the worker/transcriber submits
+  `POST /worker/v1/jobs/:id/progress` updates.
+- Final worker result edits the acknowledgement to the transcript, and Mongo has
+  a completed `TranscriptionJob` plus a completed `Voice` record.
+
+## Group Chat
+
+Path:
+
+1. Add the test bot to a test group.
+2. Run `/transcribeAll` until the bot says it will transcribe all audio.
+3. Send a voice message as a regular group message.
+4. Reply to a different voice message with `/transcribe`.
+5. Toggle `/silent`, then repeat one queued-transcription path.
+
+Expected result:
+
+- Group messages are ignored only when `transcribeAllAudio` is false.
+- With `transcribeAllAudio` enabled, a group voice message creates a queued job
+  and replies to the source message.
+- Reply `/transcribe` queues the replied-to voice/audio/document/video note.
+- Silent mode suppresses optional noise but does not prevent queue creation.
+- Worker completion publishes the transcript back into the group.
+
+## Evidence To Capture
+
+For Kaneo or PR review, capture:
+
+- Commands and pass/fail output for every automated proof.
+- Telegram screenshots for `/help`, donation wording, queued acknowledgement,
+  any progress edit, and final transcript.
+- Mongo document ids for the tested `TranscriptionJob` and `Voice`.
+- Any worker logs showing claim, download, heartbeat, result, or failure.
+- Follow-up Kaneo task links for defects that are outside the QA branch scope.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "distribute": "node dist/app.js",
     "develop": "concurrently -k -i -p \"[{name}]\" -n \"Node,TypeScript\" -c \"yellow.bold,cyan.bold\" \"yarn watch-js\" \"yarn watch-ts\"",
     "build-ts": "tsc --skipLibCheck",
+    "test:qa-vnext": "node scripts/qa-vnext-proof.js",
     "test:worker-client": "node scripts/worker-client-proof.js",
     "test:worker-e2e": "node scripts/worker-e2e-proof.js",
     "test:worker-api": "node scripts/worker-api-proof.js",

--- a/scripts/qa-vnext-proof.js
+++ b/scripts/qa-vnext-proof.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+process.env.TOKEN = process.env.TOKEN || '000000:test-token'
+process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_dummy'
+process.env.VOICY_DISABLE_TELEGRAM_PUBLISH = '1'
+process.env.WIT_LANGUAGES = process.env.WIT_LANGUAGES || '{"English":"token"}'
+
+require('reflect-metadata')
+require('module-alias/register')
+
+const fs = require('fs/promises')
+const http = require('http')
+const https = require('https')
+const mongoose = require('mongoose')
+const os = require('os')
+const path = require('path')
+const { webhookApp } = require('../dist/helpers/startWebhook')
+const { VoiceModel } = require('../dist/models/Voice')
+const {
+  TranscriptionJobModel,
+  TranscriptionJobSourceKind,
+  TranscriptionJobStatus,
+} = require('../dist/models/TranscriptionJob')
+const {
+  WorkerClientModel,
+  hashWorkerToken,
+} = require('../dist/models/WorkerClient')
+const {
+  loadConfig,
+  processNextJob,
+} = require('../dist/workerClient/runWindowsWorker')
+
+const SAMPLE_AUDIO_URL =
+  'https://raw.githubusercontent.com/Jakobovski/free-spoken-digit-dataset/master/recordings/0_jackson_0.wav'
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function fetchBuffer(url) {
+  const client = url.startsWith('https:') ? https : http
+  return new Promise((resolve, reject) => {
+    client
+      .get(url, (response) => {
+        if (
+          response.statusCode >= 300 &&
+          response.statusCode < 400 &&
+          response.headers.location
+        ) {
+          response.resume()
+          fetchBuffer(new URL(response.headers.location, url).toString())
+            .then(resolve)
+            .catch(reject)
+          return
+        }
+
+        if (response.statusCode !== 200) {
+          response.resume()
+          reject(
+            new Error(`sample download failed with ${response.statusCode}`)
+          )
+          return
+        }
+
+        const chunks = []
+        response.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+        response.on('end', () => resolve(Buffer.concat(chunks)))
+      })
+      .on('error', reject)
+  })
+}
+
+function listen(app) {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => resolve(server))
+  })
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+}
+
+function createAudioServer(sampleAudio) {
+  let downloads = 0
+  const server = http.createServer((request, response) => {
+    if (request.url !== '/sample-voice.wav') {
+      response.writeHead(404)
+      response.end()
+      return
+    }
+    downloads += 1
+    response.writeHead(200, {
+      'Content-Type': 'audio/wav',
+      'Content-Length': sampleAudio.length,
+    })
+    response.end(sampleAudio)
+  })
+  return { server, downloads: () => downloads }
+}
+
+async function cleanup() {
+  await Promise.all([
+    WorkerClientModel.deleteMany({ name: /^qa-vnext-/ }),
+    TranscriptionJobModel.deleteMany({ chatId: 'qa-vnext-chat' }),
+    VoiceModel.deleteMany({ chatId: 'qa-vnext-chat' }),
+  ])
+}
+
+async function main() {
+  if (!process.env.MONGO) {
+    throw new Error('MONGO is required for the vNext QA proof')
+  }
+
+  const sampleAudio = await fetchBuffer(SAMPLE_AUDIO_URL)
+  assert(sampleAudio.length > 1000, 'downloaded sample audio is too small')
+  assert(
+    sampleAudio.subarray(0, 4).toString('ascii') === 'RIFF',
+    'sample audio should be a WAV/RIFF file'
+  )
+
+  const samplePath = path.join(
+    os.tmpdir(),
+    `voicy-vnext-sample-${process.pid}.wav`
+  )
+  await fs.writeFile(samplePath, sampleAudio)
+
+  await mongoose.connect(process.env.MONGO)
+  await cleanup()
+
+  const audioProof = createAudioServer(sampleAudio)
+  const audioServer = await listen(audioProof.server)
+  const apiServer = await listen(webhookApp)
+  const token = 'qa-vnext-worker-token'
+
+  try {
+    await WorkerClientModel.create({
+      name: 'qa-vnext-worker',
+      tokenHash: hashWorkerToken(token),
+    })
+    const queuedJob = await TranscriptionJobModel.create({
+      chatId: 'qa-vnext-chat',
+      telegramChatId: '123',
+      sourceMessageId: 100,
+      statusMessageId: 101,
+      fileId: 'qa-vnext-file',
+      fileSize: sampleAudio.length,
+      mimeType: 'audio/wav',
+      sourceKind: TranscriptionJobSourceKind.voice,
+      sourceUrl: `http://127.0.0.1:${
+        audioServer.address().port
+      }/sample-voice.wav`,
+      recognitionLanguageHint: 'en',
+    })
+
+    const config = loadConfig({
+      VOICY_WORKER_API_URL: `http://127.0.0.1:${
+        apiServer.address().port
+      }/worker/v1`,
+      VOICY_WORKER_TOKEN: token,
+      VOICY_WORKER_TRANSCRIBE_COMMAND:
+        'node scripts/fake-transcriber.js {input} {output}',
+      VOICY_WORKER_WORK_DIR: path.join(
+        os.tmpdir(),
+        `voicy-vnext-qa-${process.pid}`
+      ),
+      VOICY_WORKER_ENGINE: 'proof-engine',
+      VOICY_WORKER_MODEL: 'proof-model',
+    })
+
+    const processed = await processNextJob(config, {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    })
+    assert(processed, 'worker should process the queued sample voice job')
+    assert(
+      audioProof.downloads() === 1,
+      'worker should download sample audio once'
+    )
+
+    const completedJob = await TranscriptionJobModel.findById(queuedJob._id)
+    assert(
+      completedJob.status === TranscriptionJobStatus.completed,
+      'sample voice job should complete'
+    )
+    assert(
+      completedJob.resultText === 'fake transcript from worker client proof',
+      'sample voice job should store transcript text'
+    )
+
+    const voice = await VoiceModel.findOne({ chatId: 'qa-vnext-chat' })
+    assert(voice, 'sample voice job should create a Voice record')
+    assert(
+      voice.sourceType === 'voice',
+      'Voice record should preserve source type'
+    )
+    assert(
+      voice.mimeType === 'audio/wav',
+      'Voice record should preserve MIME type'
+    )
+
+    console.log(`vNext QA proof passed with sample ${SAMPLE_AUDIO_URL}`)
+    console.log(`downloaded sample bytes: ${sampleAudio.length}`)
+    console.log(`local sample copy: ${samplePath}`)
+  } finally {
+    await close(apiServer)
+    await close(audioServer)
+    await cleanup()
+    await mongoose.disconnect()
+    await fs.rm(samplePath, { force: true })
+  }
+}
+
+main().catch(async (error) => {
+  console.error(error)
+  await mongoose.disconnect().catch(() => undefined)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- add a repeatable Voicy vNext QA checklist covering automated proofs, private Telegram chat, and group-chat regression paths
- add `yarn test:qa-vnext`, which downloads a real public WAV speech sample, serves it as a queued voice source, runs the worker client against the local worker API, and verifies completed TranscriptionJob + Voice records

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 yarn build-ts`
- `COREPACK_ENABLE_AUTO_PIN=0 yarn lint`
- `COREPACK_ENABLE_AUTO_PIN=0 MONGO=mongodb://127.0.0.1:27017/voicy_kaneo_7_worker_api yarn test:worker-api`
- `COREPACK_ENABLE_AUTO_PIN=0 yarn test:worker-client`
- `COREPACK_ENABLE_AUTO_PIN=0 MONGO=mongodb://127.0.0.1:27017/voicy_kaneo_7_worker_e2e yarn test:worker-e2e`
- `COREPACK_ENABLE_AUTO_PIN=0 MONGO=mongodb://127.0.0.1:27017/voicy_kaneo_7_qa yarn test:qa-vnext`
- `node --check scripts/qa-vnext-proof.js`
- `./node_modules/.bin/prettier --check scripts/qa-vnext-proof.js docs/voicy-vnext-qa.md`

## Manual QA Handoff
Interactive Telegram validation could not be completed in this unattended run because the Computer Use app/session listing timed out. The exact Telegram private-chat and group-chat paths, expected results, and evidence to capture are documented in `docs/voicy-vnext-qa.md`.