### PR TITLE
Document authenticated Windows GPU worker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,45 @@ See examples in `.env.sample` file.
 
 Any commit pushed to `main` gets deployed to [@voicybot](https://t.me/voicybot) via [CI Ninja](https://github.com/backmeupplz/ci-ninja).
 
+## Windows GPU transcription worker
+
+Voicy queues incoming Telegram audio in Mongo and expects one or more
+authenticated worker clients to process those jobs. The Windows GPU worker is
+the supported local setup for Nikita's RTX 4070 Ti machine: it polls the backend
+worker API, downloads the queued audio source, runs a local transcription command
+on CUDA, and uploads the final transcript back to Voicy.
+
+The worker API is mounted at `/worker/v1` and requires
+`Authorization: Bearer <VOICY_WORKER_TOKEN>` on every request. Create a worker
+token from a trusted backend shell after building the TypeScript output:
+
+```sh
+yarn build-ts
+MONGO='mongodb://...' yarn worker:create-client windows-4070-ti
+```
+
+Store the printed token only in the Windows worker environment as
+`VOICY_WORKER_TOKEN`; the backend stores only its SHA-256 hash. If a token is
+lost or exposed, create a replacement token and disable the old `WorkerClient`
+record in Mongo by setting `enabled` to `false`.
+
+On the Windows machine, build this repo, install FFmpeg, Node.js 20+, Python
+3.11, current NVIDIA drivers, and a CUDA-capable transcription stack such as
+`faster-whisper`. Configure the worker with:
+
+```powershell
+$env:VOICY_WORKER_API_URL = "https://<voicy-host>/worker/v1"
+$env:VOICY_WORKER_TOKEN = "voicy_worker_..."
+$env:VOICY_WORKER_WORK_DIR = "C:\voicy-worker\jobs"
+$env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language}"
+yarn worker:run
+```
+
+See [`docs/windows-worker-client.md`](docs/windows-worker-client.md) for the
+full Windows setup, environment variables, retry behavior, and validation steps.
+See [`docs/worker-api.md`](docs/worker-api.md) for the authenticated API
+contract.
+
 ## License
 
 MIT — use for any purpose. Would be great if you could leave a note about the original developers. Thanks!

--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -2,11 +2,12 @@
 
 This worker runs on Nikita's Windows RTX 4070 Ti machine. It claims queued
 Voicy transcription jobs from the backend, downloads the Telegram audio file,
-runs a local GPU transcription command, and uploads the final transcript.
+runs a local GPU transcription command, and uploads the final transcript over
+the authenticated worker API.
 
 ## Backend Prep
 
-Build the server code and create a worker token:
+Build the server code and create a worker token from a trusted backend shell:
 
 ```sh
 yarn build-ts
@@ -14,7 +15,32 @@ MONGO='mongodb://...' yarn worker:create-client windows-4070-ti
 ```
 
 Store the printed token in the Windows worker environment as
-`VOICY_WORKER_TOKEN`. The backend stores only its hash.
+`VOICY_WORKER_TOKEN`. The token is shown only once; the backend stores only its
+SHA-256 hash in the `WorkerClient` collection.
+
+If the token is lost or exposed, create a new worker client token and disable
+the old Mongo record by setting `enabled` to `false`. Do not commit the token to
+this repo, paste it into task comments, or share it in logs.
+
+## Authentication and Security Model
+
+The worker API is mounted under `/worker/v1`. Every request must include:
+
+```text
+Authorization: Bearer <VOICY_WORKER_TOKEN>
+```
+
+The server accepts the request only when the token hash matches an enabled
+`WorkerClient`. Missing, malformed, disabled, or unknown tokens receive `401`.
+Worker clients cannot create arbitrary transcription jobs through this API; jobs
+are created by the bot/backend from Telegram messages, and authenticated workers
+can only claim queued jobs, read the source for jobs they own, heartbeat, upload
+progress, upload final results, or report failures.
+
+Run the worker from a dedicated Windows account or service with access only to
+its work directory and environment variables. Keep `VOICY_WORKER_WORK_DIR` local
+to the machine because it temporarily stores downloaded Telegram audio and
+transcript JSON files.
 
 ## Windows GPU Setup
 
@@ -89,7 +115,7 @@ yarn build-ts
 Set environment variables:
 
 ```powershell
-$env:VOICY_WORKER_API_URL = "https://voicy.example.com/worker/v1"
+$env:VOICY_WORKER_API_URL = "https://<voicy-host>/worker/v1"
 $env:VOICY_WORKER_TOKEN = "voicy_worker_..."
 $env:VOICY_WORKER_WORK_DIR = "C:\voicy-worker\jobs"
 $env:VOICY_WORKER_ENGINE = "faster-whisper"
@@ -111,6 +137,10 @@ Run the worker:
 ```powershell
 yarn worker:run
 ```
+
+For a one-job smoke test, add `VOICY_WORKER_IDLE_EXIT=1` before running the
+worker. The process exits after processing one available job, or exits
+immediately if no queued job is available.
 
 ## Runtime Behavior
 

--- a/docs/worker-api.md
+++ b/docs/worker-api.md
@@ -1,17 +1,26 @@
 # Voicy Worker API
 
 Worker clients authenticate with `Authorization: Bearer <token>`. Tokens are
-stored in Mongo only as SHA-256 hashes in `WorkerClient`.
+stored in Mongo only as SHA-256 hashes in `WorkerClient`, and only enabled
+clients are accepted.
 
-The Windows worker client is documented in
-[`docs/windows-worker-client.md`](windows-worker-client.md).
-
-Create a token after building the TypeScript output:
+Create a token from a trusted backend shell after building TypeScript:
 
 ```sh
 yarn build-ts
 MONGO='mongodb://...' yarn worker:create-client windows-4070-ti
 ```
+
+Store the printed token as `VOICY_WORKER_TOKEN` on the worker host. The token is
+not recoverable from Mongo; if it is lost or exposed, create a new token and
+disable the old `WorkerClient` record by setting `enabled` to `false`.
+
+The Windows worker client is documented in
+[`docs/windows-worker-client.md`](windows-worker-client.md).
+
+The worker API is not a public job-submission API. Voicy creates transcription
+jobs from Telegram input, then authenticated workers can claim and complete only
+the jobs they own.
 
 ## Endpoints
 


### PR DESCRIPTION
## Summary
- add README guidance for the authenticated Windows GPU transcription worker
- document token generation, storage, revocation, and worker API security boundaries
- align Windows worker and API docs with the current Bearer-token implementation

## Validation
- yarn install --frozen-lockfile
- yarn build-ts
- git diff --check

Kaneo: VOI-KANEO-14