### PR TITLE
Add local Whisper worker proof

### DIFF
--- a/docs/qa-2026-05-01.md
+++ b/docs/qa-2026-05-01.md
@@ -1,0 +1,88 @@
+# Voicy QA report — 2026-05-01
+
+## What I tested
+
+### Real Telegram text-command checks against `@okamikron_bot`
+
+- `/start` → passed, English onboarding text returned
+- `/help` → passed, English help text returned
+- `/language` → passed in both English and Russian UI states
+- `/help` after switching UI to Russian → passed, Russian help text returned
+- `/l ru` → bot state changed to Russian successfully, but the current Telegram Web automation helper was flaky when sending slash commands with arguments and timed out waiting for the sent text echo
+
+### Local real transcription checks with OpenAI Whisper CLI
+
+Used local Whisper (`turbo`) on this Mac against generated English and Russian speech samples.
+
+Results:
+
+- English sample → `Hello world, this is a voicey transcription test.`
+- Russian sample → `Привет мир, это проверка расшифровки для войси.`
+
+### Real worker/API pipeline checks
+
+Ran the Voicy worker pipeline end-to-end with real Whisper transcription and verified that:
+
+- jobs moved to `completed`
+- transcript text was stored
+- `Voice` records were created
+- recognized language and worker engine metadata were persisted
+
+## Issues found
+
+### 1. Localization audit currently fails
+
+`yarn audit-locales` exits non-zero.
+
+Observed problems:
+
+- many non-primary locales are partial and fall back heavily to English
+- stale keys remain across locales
+- `en.yaml` and `ru.yaml` still contain stale legacy keys tied to removed engine-selection flows
+
+Impact:
+
+- translation coverage outside the primary languages is incomplete
+- locale hygiene is not clean enough for a passing audit gate
+
+### 2. Dependency stack still has transitive audit debt
+
+A conservative dependency cleanup has landed, including `packageManager`, unused dependency removal, and safe direct dependency updates. Remaining audit debt appears tied mostly to older transitive dependency trees and should be handled in smaller follow-up upgrades.
+
+Impact:
+
+- lower than before, but still real maintenance/security risk
+- risky major upgrades should stay separate from the local-worker transcription path
+
+### 3. Telegram Web QA helper still has a gap for file/audio send automation
+
+The current CDP-based helper is solid for text send/verify, but not yet a clean end-to-end path for uploading an audio file and sending it through Telegram Web unattended.
+
+Impact:
+
+- full real-user audio QA through Telegram Web is still partly manual/tooling-limited
+- text-command QA is reliable; voice-upload QA automation is not yet equally mature
+
+### 4. Local bot runtime does not include worker config by default
+
+The checked-in local `.env` has bot basics, but not a ready local worker configuration.
+
+Impact:
+
+- a local bot instance can queue work only if a separate worker is configured and run explicitly
+- easy to mistake a healthy queueing flow for a broken transcription flow during local QA
+
+## What passed cleanly
+
+- `yarn build-ts`
+- `yarn lint`
+- English/Russian bot text flows over real Telegram Web
+- local Whisper transcription on English and Russian speech
+- worker client proof with local OpenAI Whisper CLI using `VOICY_WHISPER_MODEL=tiny yarn test:worker-local-stt`
+- worker/API persistence path with real transcription output
+
+## Follow-up created
+
+Created Kaneo task in Voicy project:
+
+- **VOI-11** — `Bump Voicy dependencies to current versions and remove unused packages`

--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -65,7 +65,9 @@ python -m pip install faster-whisper
 `large-v3` model on CUDA with `float16`; reduce to `medium` if VRAM or latency
 becomes a problem.
 
-Create `C:\voicy-worker\transcribe.py`:
+The checked-in `scripts/whisper-transcriber.js` adapter can run the local OpenAI Whisper CLI directly and emit the worker JSON format. For the Windows GPU host you can keep using a custom `faster-whisper` Python command if that is faster, as long as it writes this same JSON shape to `{output}`.
+
+Example `C:\voicy-worker\transcribe.py` for `faster-whisper`:
 
 ```python
 import json
@@ -125,6 +127,15 @@ $env:VOICY_WORKER_POLL_INTERVAL_MS = "5000"
 $env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language}"
 ```
 
+For CPU or smoke-test environments with the OpenAI Whisper CLI installed, use the checked-in adapter instead:
+
+```powershell
+$env:VOICY_WHISPER_MODEL = "small"
+$env:VOICY_WORKER_ENGINE = "openai-whisper-cli"
+$env:VOICY_WORKER_MODEL = "small"
+$env:VOICY_WORKER_TRANSCRIBE_COMMAND = "node scripts/whisper-transcriber.js {input} {output} {language}"
+```
+
 Optional:
 
 - `VOICY_WORKER_LANGUAGE=en` forces a language when the queued job has no hint.
@@ -177,6 +188,7 @@ Local code validation:
 yarn build-ts
 yarn lint
 yarn test:worker-client
+VOICY_WHISPER_MODEL=tiny yarn test:worker-local-stt
 MONGO=mongodb://127.0.0.1:27017/voicy_worker_proof yarn test:worker-e2e
 ```
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:qa-vnext": "node scripts/qa-vnext-proof.js",
     "test:worker-client": "node scripts/worker-client-proof.js",
     "test:worker-e2e": "node scripts/worker-e2e-proof.js",
+    "test:worker-local-stt": "node scripts/local-whisper-worker-proof.js",
     "test:worker-api": "node scripts/worker-api-proof.js",
     "worker:create-client": "node scripts/create-worker-client.js",
     "worker:run": "node dist/workerClient/runWindowsWorker.js",

--- a/scripts/local-whisper-worker-proof.js
+++ b/scripts/local-whisper-worker-proof.js
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+const fs = require('fs/promises')
+const http = require('http')
+const os = require('os')
+const path = require('path')
+const { spawn } = require('child_process')
+
+const {
+  loadConfig,
+  processNextJob,
+} = require('../dist/workerClient/runWindowsWorker')
+
+const SAMPLE_TEXT = 'Hello world, this is a local transcription test.'
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const stdout = []
+    const stderr = []
+
+    child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)))
+    child.stderr.on('data', (chunk) => stderr.push(Buffer.from(chunk)))
+    child.on('error', reject)
+    child.on('close', (code) => {
+      const output = Buffer.concat(stdout).toString('utf8')
+      const errorOutput = Buffer.concat(stderr).toString('utf8')
+      if (code !== 0) {
+        reject(
+          new Error(
+            `${command} exited with ${code}: ${errorOutput || output}`.trim()
+          )
+        )
+        return
+      }
+      resolve({ output, errorOutput })
+    })
+  })
+}
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+}
+
+function readJson(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = []
+    request.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+    request.on('end', () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')))
+      } catch (error) {
+        reject(error)
+      }
+    })
+    request.on('error', reject)
+  })
+}
+
+async function createSampleAudio(workDir) {
+  const aiffPath = path.join(workDir, 'sample.aiff')
+  const wavPath = path.join(workDir, 'sample.wav')
+  await run('say', ['-v', 'Samantha', '-o', aiffPath, SAMPLE_TEXT])
+  await run('ffmpeg', ['-y', '-loglevel', 'error', '-i', aiffPath, wavPath])
+  return fs.readFile(wavPath)
+}
+
+function createProofServer(sampleAudio) {
+  const state = {
+    claimed: false,
+    result: undefined,
+    failure: undefined,
+  }
+
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url, 'http://127.0.0.1')
+    const token = request.headers.authorization
+    if (token !== 'Bearer local-whisper-proof-token') {
+      response.writeHead(401, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify({ error: 'invalid_worker_token' }))
+      return
+    }
+
+    if (request.method === 'POST' && url.pathname === '/worker/v1/jobs/claim') {
+      if (state.claimed) {
+        response.writeHead(204)
+        response.end()
+        return
+      }
+      state.claimed = true
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id: 'local-whisper-proof-job',
+            status: 'processing',
+            sourceKind: 'voice',
+            mimeType: 'audio/wav',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    if (
+      request.method === 'GET' &&
+      url.pathname === '/worker/v1/jobs/local-whisper-proof-job/source'
+    ) {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          source: {
+            sourceUrl: `http://127.0.0.1:${server.address().port}/audio.wav`,
+            sourceKind: 'voice',
+            mimeType: 'audio/wav',
+            fileId: 'local-whisper-proof-file',
+          },
+        })
+      )
+      return
+    }
+
+    if (request.method === 'GET' && url.pathname === '/audio.wav') {
+      response.writeHead(200, {
+        'Content-Type': 'audio/wav',
+        'Content-Length': sampleAudio.length,
+      })
+      response.end(sampleAudio)
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/local-whisper-proof-job/heartbeat'
+    ) {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify({ job: { id: 'local-whisper-proof-job' } }))
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/local-whisper-proof-job/result'
+    ) {
+      state.result = await readJson(request)
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: { id: 'local-whisper-proof-job', status: 'completed' },
+        })
+      )
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/local-whisper-proof-job/failure'
+    ) {
+      state.failure = await readJson(request)
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: { id: 'local-whisper-proof-job', status: 'queued' },
+        })
+      )
+      return
+    }
+
+    response.writeHead(404, { 'Content-Type': 'application/json' })
+    response.end(JSON.stringify({ error: 'not_found' }))
+  })
+
+  return { server, state }
+}
+
+async function main() {
+  const workDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), `voicy-local-whisper-proof-${process.pid}-`)
+  )
+  const workerDir = path.join(workDir, 'worker')
+  const sampleAudio = await createSampleAudio(workDir)
+  const { server, state } = createProofServer(sampleAudio)
+  await listen(server)
+
+  try {
+    const config = loadConfig({
+      VOICY_WORKER_API_URL: `http://127.0.0.1:${
+        server.address().port
+      }/worker/v1`,
+      VOICY_WORKER_TOKEN: 'local-whisper-proof-token',
+      VOICY_WORKER_TRANSCRIBE_COMMAND:
+        'node scripts/whisper-transcriber.js {input} {output} {language}',
+      VOICY_WORKER_WORK_DIR: workerDir,
+      VOICY_WORKER_ENGINE: 'openai-whisper-cli',
+      VOICY_WORKER_MODEL: process.env.VOICY_WHISPER_MODEL || 'tiny',
+    })
+
+    const processed = await processNextJob(config, {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    })
+
+    assert(processed, 'worker should process the local Whisper job')
+    assert(!state.failure, 'local Whisper worker should not report failure')
+    assert(state.result, 'worker should upload a local Whisper result')
+
+    const text = String(state.result.text || '').toLowerCase()
+    assert(text.includes('hello'), 'transcript should include "hello"')
+    assert(
+      text.includes('transcription'),
+      'transcript should include "transcription"'
+    )
+    assert(
+      state.result.engine === 'openai-whisper-cli',
+      'worker should report the local Whisper engine'
+    )
+
+    console.log('local Whisper worker proof passed')
+    console.log(`transcript: ${state.result.text}`)
+  } finally {
+    await close(server)
+    await fs.rm(workDir, { recursive: true, force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/whisper-transcriber.js
+++ b/scripts/whisper-transcriber.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+const fs = require('fs/promises')
+const os = require('os')
+const path = require('path')
+const { spawn } = require('child_process')
+
+const inputPath = process.argv[2]
+const outputPath = process.argv[3]
+const language = process.argv[4]
+
+if (!inputPath || !outputPath) {
+  throw new Error(
+    'Usage: node scripts/whisper-transcriber.js <input> <output> [language]'
+  )
+}
+
+const model = process.env.VOICY_WHISPER_MODEL || 'turbo'
+const device = process.env.VOICY_WHISPER_DEVICE
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const stdout = []
+    const stderr = []
+
+    child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)))
+    child.stderr.on('data', (chunk) => stderr.push(Buffer.from(chunk)))
+    child.on('error', reject)
+    child.on('close', (code) => {
+      const output = Buffer.concat(stdout).toString('utf8')
+      const errorOutput = Buffer.concat(stderr).toString('utf8')
+      if (code !== 0) {
+        reject(
+          new Error(
+            `whisper exited with ${code}: ${errorOutput || output}`.trim()
+          )
+        )
+        return
+      }
+      resolve({ output, errorOutput })
+    })
+  })
+}
+
+function formatTimeCode(seconds) {
+  const safeSeconds = Math.max(0, Number(seconds) || 0)
+  const minutes = Math.floor(safeSeconds / 60)
+  const wholeSeconds = Math.floor(safeSeconds % 60)
+  return `${String(minutes).padStart(2, '0')}:${String(wholeSeconds).padStart(
+    2,
+    '0'
+  )}`
+}
+
+async function findWhisperJson(outputDir, inputPath) {
+  const preferred = path.join(
+    outputDir,
+    `${path.basename(inputPath, path.extname(inputPath))}.json`
+  )
+  try {
+    return await fs.readFile(preferred, 'utf8')
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  const entries = await fs.readdir(outputDir)
+  const jsonFile = entries.find((entry) => entry.endsWith('.json'))
+  if (!jsonFile) {
+    throw new Error('whisper did not produce a JSON transcript')
+  }
+  return fs.readFile(path.join(outputDir, jsonFile), 'utf8')
+}
+
+async function main() {
+  const outputDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), `voicy-whisper-${process.pid}-`)
+  )
+
+  try {
+    const args = [
+      inputPath,
+      '--model',
+      model,
+      '--output_format',
+      'json',
+      '--output_dir',
+      outputDir,
+      '--verbose',
+      'False',
+    ]
+
+    if (device) {
+      args.push('--device', device)
+    }
+    if (language) {
+      args.push('--language', language)
+    }
+
+    await run('whisper', args)
+    const rawTranscript = await findWhisperJson(outputDir, inputPath)
+    const transcript = JSON.parse(rawTranscript)
+    const text = String(transcript.text || '').trim()
+
+    if (!text) {
+      throw new Error('whisper produced an empty transcript')
+    }
+
+    const segments = Array.isArray(transcript.segments)
+      ? transcript.segments
+      : []
+    const parts = segments
+      .map((segment) => ({
+        timeCode: formatTimeCode(segment.start),
+        text: String(segment.text || '').trim(),
+      }))
+      .filter((part) => part.text)
+
+    const lastSegment = segments[segments.length - 1]
+    const result = {
+      text,
+      parts: parts.length ? parts : [{ timeCode: '00:00', text }],
+      language: transcript.language || language || undefined,
+      duration: lastSegment?.end,
+      metadata: {
+        engine: 'openai-whisper-cli',
+        model,
+        device: device || 'default',
+      },
+    }
+
+    await fs.writeFile(outputPath, JSON.stringify(result), 'utf8')
+  } finally {
+    await fs.rm(outputDir, { recursive: true, force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- add a local OpenAI Whisper CLI transcriber adapter for worker commands
- add a worker proof that synthesizes audio locally, runs Whisper, and verifies the uploaded transcript
- document CPU/OpenAI Whisper CLI and GPU faster-whisper worker setup
- commit the 2026-05-01 QA report

## Validation
- yarn build-ts
- yarn lint
- yarn test:worker-client
- VOICY_WHISPER_MODEL=tiny yarn test:worker-local-stt
- prettier check for package/docs/new scripts

Note: Mongo was not running locally, so Mongo-backed worker API/e2e proofs were not rerun in this pass.