### PR TITLE
Align Voicy command names

### DIFF
--- a/docs/voicy-vnext-qa.md
+++ b/docs/voicy-vnext-qa.md
@@ -62,7 +62,7 @@ Expected result:
 Path:
 
 1. Add the test bot to a test group.
-2. Run `/transcribeAll` until the bot says it will transcribe all audio.
+2. Run `/transcribe_all` until the bot says it will transcribe all audio.
 3. Send a voice message as a regular group message.
 4. Reply to a different voice message with `/transcribe`.
 5. Toggle `/silent`, then repeat one queued-transcription path.

--- a/src/app.ts
+++ b/src/app.ts
@@ -82,7 +82,6 @@ async function runApp() {
   bot.command('l', checkAdminLock, handleL)
   bot.command('addPromoException', checkSuperAdmin, handleAddPromoException)
   bot.command('viewPromoExceptions', checkSuperAdmin, handleViewPromoExceptions)
-  bot.command('transcribeAll', checkAdminLock, handleTranscribeAll)
   bot.command('transcribe_all', checkAdminLock, handleTranscribeAll)
   bot.command('transcribe', checkAdminLock, handleTranscribe)
   // Callabcks


### PR DESCRIPTION
## Summary
- remove the stale `/transcribeAll` Telegram handler alias so runtime registration matches the bot menu and help text
- update the QA checklist to use `/transcribe_all`

## Validation
- `node scripts/audit-localizations.js`
- `yarn build-ts`
- `yarn lint`