### PR TITLE
Fix Telegram Markdown escaping for bot handles

### DIFF
--- a/src/commands/handleDonate.ts
+++ b/src/commands/handleDonate.ts
@@ -1,3 +1,4 @@
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import { stripe } from '@/helpers/stripe'
 import Context from '@/models/Context'
 import logAnswerTime from '@/helpers/logAnswerTime'
@@ -5,7 +6,7 @@ import logAnswerTime from '@/helpers/logAnswerTime'
 export default async function handleDonate(ctx: Context) {
   console.log('/donate called', !!ctx.dbchat.paid)
   if (ctx.dbchat.paid) {
-    await ctx.reply(ctx.i18n.t('already_paid'), {
+    await ctx.reply(markdownI18n(ctx, 'already_paid'), {
       parse_mode: 'Markdown',
       disable_web_page_preview: true,
     })
@@ -31,7 +32,7 @@ export default async function handleDonate(ctx: Context) {
         },
       })
       console.log('Not paid, sending message')
-      await ctx.reply(ctx.i18n.t('pay'), {
+      await ctx.reply(markdownI18n(ctx, 'pay'), {
         parse_mode: 'Markdown',
         disable_web_page_preview: true,
         reply_markup: {

--- a/src/commands/handleGeeky.ts
+++ b/src/commands/handleGeeky.ts
@@ -1,8 +1,9 @@
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import logAnswerTime from '@/helpers/logAnswerTime'
 
 export default async function handleGeeky(ctx: Context) {
-  await ctx.reply(ctx.i18n.t('geeky'), {
+  await ctx.reply(markdownI18n(ctx, 'geeky'), {
     parse_mode: 'Markdown',
   })
   logAnswerTime(ctx, '/geeky')

--- a/src/commands/handleHelp.ts
+++ b/src/commands/handleHelp.ts
@@ -1,8 +1,9 @@
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import logAnswerTime from '@/helpers/logAnswerTime'
 
 export default async function handleHelp(ctx: Context) {
-  await ctx.reply(ctx.i18n.t('help'), {
+  await ctx.reply(markdownI18n(ctx, 'help'), {
     disable_web_page_preview: true,
     parse_mode: 'Markdown',
   })

--- a/src/commands/handleLock.ts
+++ b/src/commands/handleLock.ts
@@ -1,3 +1,4 @@
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import logAnswerTime from '@/helpers/logAnswerTime'
 
@@ -5,7 +6,7 @@ export default async function handleLock(ctx: Context) {
   ctx.dbchat.adminLocked = !ctx.dbchat.adminLocked
   await ctx.dbchat.save()
   await ctx.reply(
-    ctx.i18n.t(ctx.dbchat.adminLocked ? 'lock_true' : 'lock_false'),
+    markdownI18n(ctx, ctx.dbchat.adminLocked ? 'lock_true' : 'lock_false'),
     {
       parse_mode: 'Markdown',
     }

--- a/src/commands/handleTranscribe.ts
+++ b/src/commands/handleTranscribe.ts
@@ -1,4 +1,5 @@
 import { enqueueTranscription } from '@/handlers/handleAudio'
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import fileUrl from '@/helpers/fileUrl'
 import report from '@/helpers/report'
@@ -7,7 +8,7 @@ export default async function handleTranscribe(ctx: Context) {
   try {
     if (!ctx.dbchat.paid) {
       console.log('Sending the donate message')
-      await ctx.reply(ctx.i18n.t('sunsetting'), {
+      await ctx.reply(markdownI18n(ctx, 'sunsetting'), {
         parse_mode: 'Markdown',
         reply_to_message_id: ctx.msg.message_id,
         disable_web_page_preview: true,
@@ -35,7 +36,7 @@ export default async function handleTranscribe(ctx: Context) {
     // Check size
     if (voice.file_size && voice.file_size >= 19 * 1024 * 1024) {
       if (!ctx.dbchat.silent) {
-        await ctx.reply(ctx.i18n.t('error_twenty'), {
+        await ctx.reply(markdownI18n(ctx, 'error_twenty'), {
           parse_mode: 'Markdown',
           reply_to_message_id: message.message_id,
         })
@@ -55,7 +56,7 @@ export default async function handleTranscribe(ctx: Context) {
     )
   } catch (error) {
     report(error, { ctx, location: 'handleTranscribe' })
-    await ctx.reply(ctx.i18n.t('error_queue'), {
+    await ctx.reply(markdownI18n(ctx, 'error_queue'), {
       parse_mode: 'Markdown',
       reply_to_message_id: ctx.msg?.message_id,
     })

--- a/src/commands/handleUrl.ts
+++ b/src/commands/handleUrl.ts
@@ -1,8 +1,9 @@
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import logAnswerTime from '@/helpers/logAnswerTime'
 
 export default async function handleUrl(ctx: Context) {
-  await ctx.reply(ctx.i18n.t('url'), {
+  await ctx.reply(markdownI18n(ctx, 'url'), {
     parse_mode: 'Markdown',
   })
   logAnswerTime(ctx, '/url')

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -4,6 +4,7 @@ import {
   TranscriptionJobSourceKind,
   TranscriptionJobStatus,
 } from '@/models/TranscriptionJob'
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import fileUrl from '@/helpers/fileUrl'
 import report from '@/helpers/report'
@@ -21,7 +22,7 @@ export default async function handleAudio(ctx: Context) {
   try {
     if (!ctx.dbchat.paid) {
       console.log('Sending the donate message')
-      await ctx.reply(ctx.i18n.t('sunsetting'), {
+      await ctx.reply(markdownI18n(ctx, 'sunsetting'), {
         parse_mode: 'Markdown',
         reply_to_message_id: ctx.msg.message_id,
         disable_web_page_preview: true,
@@ -60,7 +61,7 @@ export default async function handleAudio(ctx: Context) {
 }
 
 function sendLargeFileError(ctx: Context) {
-  return ctx.reply(ctx.i18n.t('error_twenty'), {
+  return ctx.reply(markdownI18n(ctx, 'error_twenty'), {
     parse_mode: 'Markdown',
     reply_to_message_id: ctx.msg.message_id,
   })
@@ -96,7 +97,7 @@ async function enqueueTranscription(
   })
 
   try {
-    const ackMessage = await ctx.reply(ctx.i18n.t('initiated'), {
+    const ackMessage = await ctx.reply(markdownI18n(ctx, 'initiated'), {
       reply_to_message_id: sourceMessage.message_id,
       parse_mode: 'Markdown',
     })
@@ -143,7 +144,7 @@ function audioFromMessage(message: Message): AudioPayload {
 
 async function sendQueueError(ctx: Context) {
   try {
-    await ctx.reply(ctx.i18n.t('error_queue'), {
+    await ctx.reply(markdownI18n(ctx, 'error_queue'), {
       parse_mode: 'Markdown',
       reply_to_message_id: ctx.msg?.message_id,
     })

--- a/src/handlers/handleSetLanguage.ts
+++ b/src/handlers/handleSetLanguage.ts
@@ -1,4 +1,5 @@
 import { findUiLanguage } from '@/helpers/language/uiLanguages'
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import languageKeyboard from '@/helpers/language/languageKeyboard'
 import logAnswerTime from '@/helpers/logAnswerTime'
@@ -13,7 +14,7 @@ export default async function handleSetLanguage(ctx: Context) {
   if (['<', '>'].includes(language)) {
     const page = +options[3]
     try {
-      await ctx.editMessageText(ctx.i18n.t('language'), {
+      await ctx.editMessageText(markdownI18n(ctx, 'language'), {
         reply_markup: languageKeyboard(
           isCommand,
           language === '<' ? page - 1 : page + 1
@@ -36,7 +37,7 @@ export default async function handleSetLanguage(ctx: Context) {
   ctx.i18n.locale(languageObject.code)
 
   await ctx.editMessageText(
-    ctx.i18n.t('language_success', {
+    markdownI18n(ctx, 'language_success', {
       language: languageObject.name,
     }),
     {

--- a/src/helpers/ensurePaidChat.ts
+++ b/src/helpers/ensurePaidChat.ts
@@ -1,10 +1,11 @@
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 
 export default async function ensurePaidChat(ctx: Context) {
   if (ctx.dbchat.paid) {
     return true
   }
-  await ctx.reply(ctx.i18n.t('sunsetting'), {
+  await ctx.reply(markdownI18n(ctx, 'sunsetting'), {
     parse_mode: 'Markdown',
     reply_to_message_id: ctx.msg.message_id,
     disable_web_page_preview: true,

--- a/src/helpers/sendStart.ts
+++ b/src/helpers/sendStart.ts
@@ -1,8 +1,9 @@
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import logAnswerTime from '@/helpers/logAnswerTime'
 
 export default async function sendStart(ctx: Context) {
-  await ctx.reply(ctx.i18n.t('start'), {
+  await ctx.reply(markdownI18n(ctx, 'start'), {
     parse_mode: 'Markdown',
   })
   logAnswerTime(ctx, '/start')

--- a/src/helpers/telegramMarkdown.ts
+++ b/src/helpers/telegramMarkdown.ts
@@ -1,0 +1,40 @@
+import type Context from '@/models/Context'
+
+type I18nReplacements = Record<string, string | number>
+
+function escapeTokenUnderscores(token: string) {
+  let escaped = ''
+  for (const character of token) {
+    escaped += character === '_' ? '\\_' : character
+  }
+  return escaped
+}
+
+export function escapeTelegramMarkdownText(text: string) {
+  return text
+    .split(/(`[^`]*`)/g)
+    .map((part) =>
+      part.startsWith('`')
+        ? part
+        : part
+            .replace(
+              /(^|[^\\])(@[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+)/g,
+              (_, prefix: string, token: string) =>
+                `${prefix}${escapeTokenUnderscores(token)}`
+            )
+            .replace(
+              /(^|[\s([{])(\/[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+)/g,
+              (_, prefix: string, token: string) =>
+                `${prefix}${escapeTokenUnderscores(token)}`
+            )
+    )
+    .join('')
+}
+
+export function markdownI18n(
+  ctx: Context,
+  key: string,
+  replacements?: I18nReplacements
+) {
+  return escapeTelegramMarkdownText(ctx.i18n.t(key, replacements))
+}

--- a/src/helpers/toggleChatBoolean.ts
+++ b/src/helpers/toggleChatBoolean.ts
@@ -1,3 +1,4 @@
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import logAnswerTime from '@/helpers/logAnswerTime'
 
@@ -19,7 +20,7 @@ export default async function toggleChatBoolean(
 ) {
   ctx.dbchat[setting] = !ctx.dbchat[setting]
   await ctx.dbchat.save()
-  await ctx.reply(ctx.i18n.t(messageForValue(ctx.dbchat[setting])), {
+  await ctx.reply(markdownI18n(ctx, messageForValue(ctx.dbchat[setting])), {
     parse_mode: 'Markdown',
   })
   logAnswerTime(ctx, logLabel)

--- a/src/middlewares/disallowPrivate.ts
+++ b/src/middlewares/disallowPrivate.ts
@@ -1,9 +1,10 @@
 import { NextFunction } from 'grammy'
+import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 
 export default function disallowPrivate(ctx: Context, next: NextFunction) {
   if (ctx.chat.type === 'private') {
-    return ctx.reply(ctx.i18n.t('error_group'), {
+    return ctx.reply(markdownI18n(ctx, 'error_group'), {
       parse_mode: 'Markdown',
     })
   }


### PR DESCRIPTION
## Summary
- Add shared Telegram Markdown formatting for localized replies so usernames and slash commands with underscores render literally.
- Route localized replies/edits that use `parse_mode: Markdown` through the formatter, including start/help and donation-gate paths.

## Validation
- `yarn build-ts`
- `yarn lint`
- focused `node -e` formatter proof for handles, commands, existing escapes, code spans, and URL paths
- Telegram Web QA via Chrome CDP `http://127.0.0.1:9222` against `@okamikron_bot` using local branch bot polling:
  - English `/start` verified `The old engine-based bot is available at @voicy_legacy_bot.`
  - English `/help` verified `Voicy now uses queued transcription workers. The old engine-based bot is available at @voicy_legacy_bot.`
  - Russian `/start` verified `Старая версия с выбором движка доступна в @voicy_legacy_bot.`
  - Russian `/help` verified `Войси теперь использует очередь и воркеры для расшифровки. Старая версия с выбором движка доступна в @voicy_legacy_bot.`

Kaneo: VOI-KANEO-15