### PR TITLE
Restore Voicy test bot runtime checks

### DIFF
--- a/docs/voicy-vnext-qa.md
+++ b/docs/voicy-vnext-qa.md
@@ -28,10 +28,30 @@ worker client against the local worker API, and verifies the completed
 Environment:
 
 - Telegram Web or desktop Telegram already logged in on this Mac.
-- Local or PR Voicy bot running with a test bot token.
+- Local Voicy test bot runtime running with the `@okamikron_bot` token. The
+  test bot is expected to be a local long-polling process for QA, not a Telegram
+  webhook service.
 - Mongo available to inspect `chats`, `transcriptionjobs`, and `voices`.
 - A worker token created with `yarn worker:create-client`.
 - A worker running with `VOICY_WORKER_IDLE_EXIT=1` for each sample message.
+
+Before testing bot copy, verify the runtime is actually consuming Telegram
+updates:
+
+```sh
+TELEGRAM_TEST_BOT_TOKEN=... TELEGRAM_TEST_BOT_USERNAME=okamikron_bot yarn test:telegram-runtime
+```
+
+The check is non-destructive: it only reads `getWebhookInfo` and does not call
+`getUpdates`, because a second `getUpdates` caller can interrupt the local
+polling runtime. It passes when Telegram reports an active webhook or no pending
+backlog. If it reports pending updates and no webhook, start the local bot
+runtime first:
+
+```sh
+yarn build-ts
+MONGO=mongodb://127.0.0.1:27017/voicy_telegram_qa TOKEN=... SALT=telegram-qa ADMIN_ID=0 ENVIRONMENT=development yarn distribute
+```
 
 Path:
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:worker-e2e": "node scripts/worker-e2e-proof.js",
     "test:worker-local-stt": "node scripts/local-whisper-worker-proof.js",
     "test:worker-api": "node scripts/worker-api-proof.js",
+    "test:telegram-runtime": "node scripts/telegram-runtime-check.js",
     "worker:create-client": "node scripts/create-worker-client.js",
     "worker:run": "node dist/workerClient/runWindowsWorker.js",
     "watch-ts": "tsc -w --skipLibCheck",

--- a/scripts/telegram-runtime-check.js
+++ b/scripts/telegram-runtime-check.js
@@ -1,0 +1,99 @@
+const token = process.env.TELEGRAM_TEST_BOT_TOKEN || process.env.TOKEN
+const expectedUsername = process.env.TELEGRAM_TEST_BOT_USERNAME
+
+function fail(message, details = {}) {
+  const error = new Error(message)
+  error.details = details
+  throw error
+}
+
+async function telegram(method, params = {}) {
+  if (!token) {
+    fail('TELEGRAM_TEST_BOT_TOKEN or TOKEN is required')
+  }
+
+  const url = new URL(`https://api.telegram.org/bot${token}/${method}`)
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, String(value))
+  }
+
+  const response = await fetch(url)
+  const body = await response.json().catch(async () => ({
+    ok: false,
+    description: await response.text(),
+  }))
+
+  return { status: response.status, body }
+}
+
+async function main() {
+  const me = await telegram('getMe')
+  if (!me.body.ok) {
+    fail('Telegram getMe failed', { status: me.status, response: me.body })
+  }
+
+  const username = me.body.result.username
+  if (expectedUsername && username !== expectedUsername.replace(/^@/, '')) {
+    fail('Telegram token points at an unexpected bot', {
+      expectedUsername,
+      actualUsername: username,
+    })
+  }
+
+  const webhook = await telegram('getWebhookInfo')
+  if (!webhook.body.ok) {
+    fail('Telegram getWebhookInfo failed', {
+      status: webhook.status,
+      response: webhook.body,
+    })
+  }
+
+  const webhookInfo = webhook.body.result
+  if (webhookInfo.url) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          bot: `@${username}`,
+          runtime: 'webhook',
+          webhook_url: webhookInfo.url,
+          pending_update_count: webhookInfo.pending_update_count,
+        },
+        null,
+        2
+      )
+    )
+    return
+  }
+
+  if (webhookInfo.pending_update_count === 0) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          bot: `@${username}`,
+          runtime: 'long-polling-or-idle-local-qa',
+          pending_update_count: 0,
+          proof:
+            'No webhook is configured and Telegram reports no pending backlog',
+        },
+        null,
+        2
+      )
+    )
+    return
+  }
+
+  fail('No webhook is configured and Telegram reports pending updates', {
+    bot: `@${username}`,
+    pending_update_count: webhookInfo.pending_update_count,
+  })
+}
+
+main().catch((error) => {
+  console.error(error.message)
+  if (error.details) {
+    console.error(JSON.stringify(error.details, null, 2))
+  }
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- document @okamikron_bot as the local long-polling QA runtime
- add a safe Telegram runtime preflight that checks getWebhookInfo without interrupting long polling
- wire the preflight into package scripts for future QA

## Validation
- yarn build-ts
- yarn lint
- ./node_modules/.bin/prettier --check package.json scripts/telegram-runtime-check.js docs/voicy-vnext-qa.md
- TELEGRAM_TEST_BOT_USERNAME=okamikron_bot yarn test:telegram-runtime
- Telegram Web CDP QA: /start, /help, /language received replies from @okamikron_bot

Runtime restored locally with launchctl services voicy-kaneo-16-mongod and voicy-kaneo-16-bot.