### PR TITLE
Add configurable worker STT model selection

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,4 +8,4 @@ VOICY_WORKER_TOKEN=voicy_worker_replace_me
 VOICY_WORKER_WORK_DIR=tmp/voicy-worker
 VOICY_WORKER_ENGINE=faster-whisper
 VOICY_WORKER_MODEL=large-v3
-VOICY_WORKER_TRANSCRIBE_COMMAND=python transcribe.py {input} {output} {language}
+VOICY_WORKER_TRANSCRIBE_COMMAND=python transcribe.py {input} {output} {language} {model}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ On the Windows machine, build this repo, install FFmpeg, Node.js 20+, Python
 $env:VOICY_WORKER_API_URL = "https://<voicy-host>/worker/v1"
 $env:VOICY_WORKER_TOKEN = "voicy_worker_..."
 $env:VOICY_WORKER_WORK_DIR = "C:\voicy-worker\jobs"
-$env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language}"
+$env:VOICY_WORKER_ENGINE = "faster-whisper"
+$env:VOICY_WORKER_MODEL = "large-v3"
+$env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language} {model}"
 yarn worker:run
 ```
 

--- a/docs/qa-2026-05-01.md
+++ b/docs/qa-2026-05-01.md
@@ -78,7 +78,7 @@ Impact:
 - `yarn lint`
 - English/Russian bot text flows over real Telegram Web
 - local Whisper transcription on English and Russian speech
-- worker client proof with local OpenAI Whisper CLI using `VOICY_WHISPER_MODEL=tiny yarn test:worker-local-stt`
+- worker client proof with local OpenAI Whisper CLI using `VOICY_WORKER_MODEL=base yarn test:worker-local-stt`
 - worker/API persistence path with real transcription output
 
 ## Follow-up created

--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -65,7 +65,24 @@ python -m pip install faster-whisper
 `large-v3` model on CUDA with `float16`; reduce to `medium` if VRAM or latency
 becomes a problem.
 
-The checked-in `scripts/whisper-transcriber.js` adapter can run the local OpenAI Whisper CLI directly and emit the worker JSON format. For the Windows GPU host you can keep using a custom `faster-whisper` Python command if that is faster, as long as it writes this same JSON shape to `{output}`.
+Use `VOICY_WORKER_MODEL` as the worker-level model selector. The worker passes
+that value to the transcription command as the `{model}` template token, exports
+it to child processes as `VOICY_WORKER_MODEL`, and records it in result
+metadata. If unset, the worker defaults to `large-v3`, which is the recommended
+quality-first model for the RTX 4070 Ti host. Use smaller models only when the
+machine cannot meet memory or latency needs.
+
+Recommended starting points:
+
+- RTX 4070 Ti / CUDA: `VOICY_WORKER_MODEL=large-v3`, `compute_type=float16`.
+- Lower VRAM GPU: try `medium`, then `small` if jobs are too slow or fail.
+- CPU or smoke-test workers: use `small`, `base`, or `tiny`; these are for
+  validation speed, not production quality.
+
+The checked-in `scripts/whisper-transcriber.js` adapter can run the local OpenAI
+Whisper CLI directly and emit the worker JSON format. For the Windows GPU host
+you can keep using a custom `faster-whisper` Python command if that is faster,
+as long as it writes this same JSON shape to `{output}`.
 
 Example `C:\voicy-worker\transcribe.py` for `faster-whisper`:
 
@@ -77,8 +94,9 @@ from faster_whisper import WhisperModel
 input_path = sys.argv[1]
 output_path = sys.argv[2]
 language = sys.argv[3] or None
+model_name = sys.argv[4] if len(sys.argv) > 4 else "large-v3"
 
-model = WhisperModel("large-v3", device="cuda", compute_type="float16")
+model = WhisperModel(model_name, device="cuda", compute_type="float16")
 segments, info = model.transcribe(input_path, language=language, vad_filter=True)
 
 parts = []
@@ -95,7 +113,7 @@ result = {
     "language": info.language,
     "duration": info.duration,
     "metadata": {
-        "model": "large-v3",
+        "model": model_name,
         "device": "cuda",
         "computeType": "float16",
     },
@@ -124,7 +142,7 @@ $env:VOICY_WORKER_ENGINE = "faster-whisper"
 $env:VOICY_WORKER_MODEL = "large-v3"
 $env:VOICY_WORKER_HEARTBEAT_INTERVAL_MS = "30000"
 $env:VOICY_WORKER_POLL_INTERVAL_MS = "5000"
-$env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language}"
+$env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language} {model}"
 ```
 
 For CPU or smoke-test environments with the OpenAI Whisper CLI installed, use the checked-in adapter instead:
@@ -175,8 +193,10 @@ For each claimed job it:
 5. Reads transcript JSON from `{output}` or plain text from stdout.
 6. Uploads the result to `POST /jobs/:id/result`.
 
-The command template supports `{input}`, `{output}`, and `{language}`. Paths are
-quoted before replacement so spaces in Windows paths are supported.
+The command template supports `{input}`, `{output}`, `{language}`, and
+`{model}`. Paths and values are quoted before replacement so spaces in Windows
+paths are supported. `scripts/whisper-transcriber.js` reads
+`VOICY_WORKER_MODEL` directly, so it does not need `{model}` in the command.
 
 ## Retry and Error Behavior
 
@@ -197,7 +217,7 @@ yarn build-ts
 yarn lint
 yarn test:worker-client
 yarn test:whisper-transcriber
-VOICY_WHISPER_MODEL=tiny yarn test:worker-local-stt
+VOICY_WORKER_MODEL=base yarn test:worker-local-stt
 MONGO=mongodb://127.0.0.1:27017/voicy_worker_proof yarn test:worker-e2e
 ```
 

--- a/scripts/fake-transcriber.js
+++ b/scripts/fake-transcriber.js
@@ -4,9 +4,12 @@ const fs = require('fs')
 
 const inputPath = process.argv[2]
 const outputPath = process.argv[3]
+const model = process.argv[4] || process.env.VOICY_WORKER_MODEL || 'proof-model'
 
 if (!inputPath || !outputPath) {
-  throw new Error('Usage: node scripts/fake-transcriber.js <input> <output>')
+  throw new Error(
+    'Usage: node scripts/fake-transcriber.js <input> <output> [model]'
+  )
 }
 
 const input = fs.readFileSync(inputPath)
@@ -23,6 +26,6 @@ fs.writeFileSync(
     ],
     language: 'en',
     duration: 1.5,
-    metadata: { model: 'proof-model' },
+    metadata: { model },
   })
 )

--- a/scripts/local-whisper-worker-proof.js
+++ b/scripts/local-whisper-worker-proof.js
@@ -84,10 +84,21 @@ function createProofServer(sampleAudio) {
     claimed: false,
     result: undefined,
     failure: undefined,
+    audioAuthorization: undefined,
   }
 
   const server = http.createServer(async (request, response) => {
     const url = new URL(request.url, 'http://127.0.0.1')
+    if (request.method === 'GET' && url.pathname === '/audio.wav') {
+      state.audioAuthorization = request.headers.authorization
+      response.writeHead(200, {
+        'Content-Type': 'audio/wav',
+        'Content-Length': sampleAudio.length,
+      })
+      response.end(sampleAudio)
+      return
+    }
+
     const token = request.headers.authorization
     if (token !== 'Bearer local-whisper-proof-token') {
       response.writeHead(401, { 'Content-Type': 'application/json' })
@@ -133,15 +144,6 @@ function createProofServer(sampleAudio) {
           },
         })
       )
-      return
-    }
-
-    if (request.method === 'GET' && url.pathname === '/audio.wav') {
-      response.writeHead(200, {
-        'Content-Type': 'audio/wav',
-        'Content-Length': sampleAudio.length,
-      })
-      response.end(sampleAudio)
       return
     }
 
@@ -208,7 +210,7 @@ async function main() {
         'node scripts/whisper-transcriber.js {input} {output} {language}',
       VOICY_WORKER_WORK_DIR: workerDir,
       VOICY_WORKER_ENGINE: 'openai-whisper-cli',
-      VOICY_WORKER_MODEL: process.env.VOICY_WHISPER_MODEL || 'tiny',
+      VOICY_WORKER_MODEL: process.env.VOICY_WORKER_MODEL || 'tiny',
     })
 
     const processed = await processNextJob(config, {
@@ -218,7 +220,12 @@ async function main() {
     })
 
     assert(processed, 'worker should process the local Whisper job')
-    assert(!state.failure, 'local Whisper worker should not report failure')
+    assert(
+      !state.failure,
+      `local Whisper worker should not report failure: ${JSON.stringify(
+        state.failure
+      )}`
+    )
     assert(state.result, 'worker should upload a local Whisper result')
 
     const text = String(state.result.text || '').toLowerCase()
@@ -230,6 +237,10 @@ async function main() {
     assert(
       state.result.engine === 'openai-whisper-cli',
       'worker should report the local Whisper engine'
+    )
+    assert(
+      !state.audioAuthorization,
+      'worker should not send its API token to source downloads'
     )
 
     console.log('local Whisper worker proof passed')

--- a/scripts/qa-vnext-proof.js
+++ b/scripts/qa-vnext-proof.js
@@ -161,7 +161,7 @@ async function main() {
       }/worker/v1`,
       VOICY_WORKER_TOKEN: token,
       VOICY_WORKER_TRANSCRIBE_COMMAND:
-        'node scripts/fake-transcriber.js {input} {output}',
+        'node scripts/fake-transcriber.js {input} {output} {model}',
       VOICY_WORKER_WORK_DIR: path.join(
         os.tmpdir(),
         `voicy-vnext-qa-${process.pid}`

--- a/scripts/whisper-transcriber.js
+++ b/scripts/whisper-transcriber.js
@@ -15,7 +15,8 @@ if (!inputPath || !outputPath) {
   )
 }
 
-const model = process.env.VOICY_WHISPER_MODEL || 'turbo'
+const model =
+  process.env.VOICY_WORKER_MODEL || process.env.VOICY_WHISPER_MODEL || 'large-v3'
 const device = process.env.VOICY_WHISPER_DEVICE
 const whisperCommand = process.env.VOICY_WHISPER_COMMAND || 'whisper'
 const defaultPathEntries = [

--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -164,7 +164,7 @@ async function main() {
       VOICY_WORKER_API_URL: baseUrl,
       VOICY_WORKER_TOKEN: 'proof-worker-token',
       VOICY_WORKER_TRANSCRIBE_COMMAND:
-        'node scripts/fake-transcriber.js {input} {output}',
+        'node scripts/fake-transcriber.js {input} {output} {model}',
       VOICY_WORKER_WORK_DIR: path.join(
         os.tmpdir(),
         `voicy-worker-proof-${process.pid}`

--- a/scripts/worker-e2e-proof.js
+++ b/scripts/worker-e2e-proof.js
@@ -101,7 +101,7 @@ async function main() {
       }/worker/v1`,
       VOICY_WORKER_TOKEN: token,
       VOICY_WORKER_TRANSCRIBE_COMMAND:
-        'node scripts/fake-transcriber.js {input} {output}',
+        'node scripts/fake-transcriber.js {input} {output} {model}',
       VOICY_WORKER_WORK_DIR: path.join(
         os.tmpdir(),
         `voicy-worker-e2e-${process.pid}`

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -14,6 +14,7 @@ const DEFAULT_POLL_INTERVAL_MS = 5000
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30000
 const DEFAULT_DOWNLOAD_TIMEOUT_MS = 300000
 const DEFAULT_WORK_DIR = path.join(process.cwd(), 'tmp', 'voicy-worker')
+const DEFAULT_WORKER_MODEL = 'large-v3'
 
 interface WorkerJob {
   id: string
@@ -65,7 +66,7 @@ interface WorkerConfig {
   idleExit: boolean
   language?: string
   engine: string
-  model?: string
+  model: string
 }
 
 interface Logger {
@@ -150,7 +151,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): WorkerConfig {
     idleExit: booleanFromEnv(env.VOICY_WORKER_IDLE_EXIT),
     language: env.VOICY_WORKER_LANGUAGE,
     engine: env.VOICY_WORKER_ENGINE || 'faster-whisper',
-    model: env.VOICY_WORKER_MODEL,
+    model:
+      env.VOICY_WORKER_MODEL || env.VOICY_WHISPER_MODEL || DEFAULT_WORKER_MODEL,
   }
 }
 
@@ -255,11 +257,27 @@ function commandForJob(
     .replace(/\{input\}/g, quoteShellValue(inputPath))
     .replace(/\{output\}/g, quoteShellValue(outputPath))
     .replace(/\{language\}/g, quoteShellValue(language || ''))
+    .replace(/\{model\}/g, quoteShellValue(config.model))
 }
 
-function runCommand(command: string): Promise<RunCommandResult> {
+function commandEnv(config: WorkerConfig) {
+  return {
+    ...process.env,
+    VOICY_WORKER_MODEL: config.model,
+    VOICY_WHISPER_MODEL: config.model,
+  }
+}
+
+function runCommand(
+  command: string,
+  config: WorkerConfig
+): Promise<RunCommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, { shell: true, windowsHide: true })
+    const child = spawn(command, {
+      shell: true,
+      windowsHide: true,
+      env: commandEnv(config),
+    })
     const stdoutChunks: Buffer[] = []
     const stderrChunks: Buffer[] = []
 
@@ -347,7 +365,7 @@ async function transcribeJob(
   await removeIfExists(outputPath)
   const language = job.recognitionLanguageHint || config.language
   const command = commandForJob(config, inputPath, outputPath, language)
-  const commandResult = await runCommand(command)
+  const commandResult = await runCommand(command, config)
   return readTranscriptionOutput(
     commandResult,
     outputPath,


### PR DESCRIPTION
## Summary
- make `VOICY_WORKER_MODEL` the resolved worker-level STT model selector with a `large-v3` default
- pass the selected model to transcriber child processes, add `{model}` command-template support, and keep local OpenAI Whisper CLI metadata aligned
- update Windows worker docs, README, env sample, and proof scripts so high-quality GPU launches can opt into the best feasible model explicitly

## Validation
- `yarn build-ts` passed
- `yarn test:worker-client` passed
- `VOICY_WORKER_MODEL=base yarn test:worker-local-stt` passed; transcript: `Hello World, this is a local transcription test.`
- `yarn lint` passed
- `git diff --check` passed

## Review guidance
- Check that the Windows `faster-whisper` example matches the intended RTX 4070 Ti launch path: `large-v3`, CUDA, `float16`, and `{model}` passed to the Python adapter.
- Manual Windows GPU QA was not run in this workspace; the local proof used the OpenAI Whisper CLI adapter with a non-default `base` model to verify model propagation and result metadata.