### PR TITLE
Fix Telegram language selection buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:worker-e2e": "node scripts/worker-e2e-proof.js",
     "test:worker-local-stt": "node scripts/local-whisper-worker-proof.js",
     "test:worker-api": "node scripts/worker-api-proof.js",
+    "test:language-selection": "node scripts/language-selection-proof.js",
     "test:telegram-runtime": "node scripts/telegram-runtime-check.js",
     "qa:telegram-upload": "node scripts/telegram-web-upload-qa.mjs",
     "worker:create-client": "node scripts/create-worker-client.js",

--- a/scripts/language-selection-proof.js
+++ b/scripts/language-selection-proof.js
@@ -1,0 +1,99 @@
+require('module-alias/register')
+
+const assert = require('assert')
+
+const handleSetLanguage = require('../dist/handlers/handleSetLanguage').default
+const handleStart = require('../dist/commands/handleStart').default
+
+function createContext({
+  telegramLanguage = 'en',
+  uiLanguage = 'en',
+  manual = false,
+} = {}) {
+  const calls = []
+  const dbchat = {
+    uiLanguage,
+    uiLanguageSelectedManually: manual,
+    async save() {
+      calls.push(['save', this.uiLanguage, this.uiLanguageSelectedManually])
+      return this
+    },
+  }
+
+  const i18n = {
+    currentLocale: uiLanguage,
+    locale(language) {
+      if (language) {
+        this.currentLocale = language
+      }
+      return this.currentLocale
+    },
+    t(key, replacements) {
+      return `${this.currentLocale}:${key}:${replacements?.language || ''}`
+    },
+  }
+
+  return {
+    ctx: {
+      timeReceived: new Date(),
+      callbackQuery: { data: 'li~1~ru' },
+      dbchat,
+      i18n,
+      editMessageText: async (text, options) =>
+        calls.push(['edit', text, options]),
+      answerCallbackQuery: async () => calls.push(['answerCallbackQuery']),
+      reply: async (text, options) => calls.push(['reply', text, options]),
+      msg: { message_id: 1 },
+      from: { language_code: telegramLanguage },
+      chat: { id: 1 },
+    },
+    calls,
+  }
+}
+
+async function provesManualLanguageSurvivesStart() {
+  const { ctx, calls } = createContext()
+
+  await handleSetLanguage(ctx)
+
+  assert.equal(ctx.dbchat.uiLanguage, 'ru')
+  assert.equal(ctx.dbchat.uiLanguageSelectedManually, true)
+  assert.deepEqual(calls[0], ['answerCallbackQuery'])
+  assert.deepEqual(calls[1], ['save', 'ru', true])
+  assert.equal(calls[2][0], 'edit')
+  assert.equal(calls[2][1], 'ru:language_success:Русский')
+
+  calls.length = 0
+
+  await handleStart(ctx)
+
+  assert.equal(ctx.dbchat.uiLanguage, 'ru')
+  assert.equal(ctx.i18n.currentLocale, 'ru')
+  assert.deepEqual(calls, [['reply', 'ru:start:', { parse_mode: 'Markdown' }]])
+}
+
+async function provesTelegramLanguageStillInitializesUnselectedChats() {
+  const { ctx, calls } = createContext({
+    telegramLanguage: 'ru',
+    uiLanguage: 'en',
+    manual: false,
+  })
+
+  await handleStart(ctx)
+
+  assert.equal(ctx.dbchat.uiLanguage, 'ru')
+  assert.equal(ctx.dbchat.uiLanguageSelectedManually, false)
+  assert.deepEqual(calls[0], ['save', 'ru', false])
+  assert.deepEqual(calls[1], ['reply', 'ru:start:', { parse_mode: 'Markdown' }])
+}
+
+Promise.resolve()
+  .then(provesManualLanguageSurvivesStart)
+  .then(provesTelegramLanguageStillInitializesUnselectedChats)
+  .then(() => {
+    console.log('language selection proof passed')
+  })
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/src/commands/handleL.ts
+++ b/src/commands/handleL.ts
@@ -15,6 +15,7 @@ export default async function handleL(ctx: Context) {
     return sendLanguage(ctx, true)
   }
   ctx.dbchat.uiLanguage = languageObject.code
+  ctx.dbchat.uiLanguageSelectedManually = true
   await ctx.dbchat.save()
   ctx.i18n.locale(languageObject.code)
   return ctx.reply(

--- a/src/handlers/handleSetLanguage.ts
+++ b/src/handlers/handleSetLanguage.ts
@@ -11,6 +11,12 @@ export default async function handleSetLanguage(ctx: Context) {
   const isCommand = +options[1] === 1
   const language = options[2]
 
+  try {
+    await ctx.answerCallbackQuery()
+  } catch (error) {
+    report(error, { ctx, location: 'handleSetLanguage.answerCallbackQuery' })
+  }
+
   if (['<', '>'].includes(language)) {
     const page = +options[3]
     try {
@@ -33,6 +39,7 @@ export default async function handleSetLanguage(ctx: Context) {
   }
 
   ctx.dbchat.uiLanguage = languageObject.code
+  ctx.dbchat.uiLanguageSelectedManually = true
   await ctx.dbchat.save()
   ctx.i18n.locale(languageObject.code)
 

--- a/src/helpers/language/setLanguageCodeFromTelegram.ts
+++ b/src/helpers/language/setLanguageCodeFromTelegram.ts
@@ -2,6 +2,11 @@ import { uiLanguageForTelegramCode } from '@/helpers/language/uiLanguages'
 import Context from '@/models/Context'
 
 export default function setLanguageCodeFromTelegram(ctx: Context) {
+  if (ctx.dbchat.uiLanguageSelectedManually) {
+    ctx.i18n.locale(ctx.dbchat.uiLanguage)
+    return ctx.dbchat
+  }
+
   ctx.dbchat.uiLanguage = uiLanguageForTelegramCode(ctx.from.language_code).code
   ctx.i18n.locale(ctx.dbchat.uiLanguage)
   return ctx.dbchat.save()

--- a/src/models/Chat.ts
+++ b/src/models/Chat.ts
@@ -19,6 +19,8 @@ export class Chat extends FindOrCreate {
   @prop({ required: true, default: 'en' })
   uiLanguage: string
   @prop({ required: true, default: false })
+  uiLanguageSelectedManually: boolean
+  @prop({ required: true, default: false })
   adminLocked: boolean
   @prop({ required: true, default: false })
   silent: boolean


### PR DESCRIPTION
## Summary
- Persist explicit UI language choices from inline buttons and /l with a manual-selection flag.
- Stop /start Telegram profile auto-detection from overwriting a manually selected UI language.
- Acknowledge language callback queries so Telegram button presses do not look ignored.
- Add a focused language-selection proof script.

## Validation
- yarn build-ts
- yarn test:language-selection
- yarn lint
- TELEGRAM_TEST_BOT_USERNAME=okamikron_bot yarn test:telegram-runtime

## Testing / Review Guidance
Automated validation covers the regression where selecting Russian via callback is followed by /start and the chat must remain Russian. Telegram runtime token check passed for @okamikron_bot with no webhook and no pending updates.

Live Telegram Web button QA was attempted via Chrome CDP at http://127.0.0.1:9222 against @okamikron_bot, but this branch runtime could not poll the bot token because an existing local process /Users/borodutch/code/voicy/dist/app.js is already polling the same token and Telegram returned 409 Conflict. Manual/external QA should use the same path once the branch runtime has exclusive access: send /l en, send /language, press Русский, verify the Russian confirmation, then send /start and verify the Russian start copy remains active.