### PR TITLE
Design streaming transcription progress policy

### DIFF
--- a/docs/streaming-transcription-progress.md
+++ b/docs/streaming-transcription-progress.md
@@ -1,0 +1,43 @@
+# Streaming Transcription Progress
+
+Voicy supports partial transcript progress through the authenticated worker API
+without requiring every worker engine to stream. Engines that only produce a
+final transcript can continue to call `POST /worker/v1/jobs/:id/result`.
+
+## Runtime Contract
+
+1. Telegram media input creates a `TranscriptionJob` with `telegramChatType`,
+   `statusMessageId` when an editable acknowledgement exists, and empty partial
+   result fields.
+2. When a worker claims a job, Voicy edits the acknowledgement to the localized
+   processing text when publishing is enabled.
+3. Streaming-capable workers can call `POST /worker/v1/jobs/:id/progress` with
+   the current `text` and/or `parts`. Voicy stores every accepted progress
+   payload on the job.
+4. Voicy only edits the Telegram status message when the progress policy allows
+   it. The default visible edit interval is 2500 ms and
+   `VOICY_PROGRESS_EDIT_INTERVAL_MS` cannot lower it below 1000 ms.
+5. Final `POST /worker/v1/jobs/:id/result` stores the completed transcript,
+   creates the legacy `Voice` record, and edits the existing status/progress
+   message when one exists. Long final transcripts are split into follow-up
+   messages.
+
+## Telegram Chat Policy
+
+Private chats, groups, and supergroups can use live progress edits when the bot
+has an editable status message. Channels do not use live progress edits:
+channel jobs skip the queued acknowledgement, keep `statusMessageId` empty, and
+publish only final text. This keeps channel behavior explicit until channel edit
+rate limits and client behavior are verified separately.
+
+## Worker Guidance
+
+Workers should send progress only for meaningful transcript changes. Segmenting
+STT engines can post the full draft-so-far text or accumulated `parts` after a
+new segment is stable. The server handles Telegram edit throttling, but workers
+should still avoid high-frequency progress calls because every accepted payload
+is persisted.
+
+The checked-in Windows worker remains final-result first. A worker adapter that
+can stream should call the progress endpoint between heartbeat and final result
+submission, then always call the result endpoint with the final transcript.

--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -178,6 +178,12 @@ For each claimed job it:
 The command template supports `{input}`, `{output}`, and `{language}`. Paths are
 quoted before replacement so spaces in Windows paths are supported.
 
+The checked-in worker client uploads the final result after the command exits.
+Streaming-capable custom workers may call `POST /jobs/:id/progress` while a
+transcription command emits stable segments, then must still call
+`POST /jobs/:id/result` with the final transcript. Voicy stores accepted partial
+payloads and throttles visible Telegram edits server-side.
+
 ## Retry and Error Behavior
 
 Download failures, command crashes, and upload failures are reported to
@@ -195,6 +201,7 @@ Local code validation:
 ```sh
 yarn build-ts
 yarn lint
+yarn test:progress-policy
 yarn test:worker-client
 yarn test:whisper-transcriber
 VOICY_WHISPER_MODEL=tiny yarn test:worker-local-stt

--- a/docs/worker-api.md
+++ b/docs/worker-api.md
@@ -84,9 +84,11 @@ Request body:
 
 Workers should call this endpoint only for meaningful transcript changes. The
 server throttles visible Telegram edits with `VOICY_PROGRESS_EDIT_INTERVAL_MS`
-(default `2500`, minimum `1000`) and stores every accepted progress payload even
-when an edit is skipped. If a job has no editable status message, progress is
-still stored and the final result will be sent as a normal reply.
+(default `2500`, clamped to minimum `1000`) and stores every accepted progress
+payload even when an edit is skipped. If a job has no editable status message,
+progress is still stored and the final result will be sent as a normal message.
+Voicy does not live-edit channel posts; channel jobs wait for final text until
+channel edit behavior is explicitly verified.
 
 ### `POST /jobs/:id/result`
 
@@ -132,5 +134,7 @@ Request body:
 - exactly one of two clients can claim a single queued job;
 - a non-owning client cannot heartbeat another worker's job;
 - progress upload stores partial transcript state for the owning worker;
+- progress edit policy throttles rapid visible edits and disables live edits in
+  channels;
 - result upload completes the job and persists transcript data;
 - retryable failure requeues while attempts remain.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:whisper-transcriber": "node scripts/whisper-transcriber-proof.js",
     "test:worker-api": "node scripts/worker-api-proof.js",
     "test:language-selection": "node scripts/language-selection-proof.js",
+    "test:progress-policy": "node scripts/progress-policy-proof.js",
     "test:telegram-runtime": "node scripts/telegram-runtime-check.js",
     "test:local-runtime-health": "node scripts/local-runtime-health.js",
     "qa:telegram-upload": "node scripts/telegram-web-upload-qa.mjs",

--- a/scripts/progress-policy-proof.js
+++ b/scripts/progress-policy-proof.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+require('module-alias/register')
+
+const {
+  DEFAULT_PROGRESS_EDIT_INTERVAL_MS,
+  MIN_PROGRESS_EDIT_INTERVAL_MS,
+  liveProgressAllowedForChatType,
+  progressEditIntervalMs,
+  shouldThrottleProgressPublish,
+} = require('../dist/helpers/transcriptionJobs/progressPublishingPolicy')
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+const baseTime = new Date('2026-05-02T00:00:00.000Z')
+
+assert(
+  progressEditIntervalMs({}) === DEFAULT_PROGRESS_EDIT_INTERVAL_MS,
+  'default progress edit interval should be used when unset'
+)
+assert(
+  progressEditIntervalMs({ VOICY_PROGRESS_EDIT_INTERVAL_MS: '500' }) ===
+    MIN_PROGRESS_EDIT_INTERVAL_MS,
+  'configured progress edit interval should be clamped to minimum'
+)
+assert(
+  progressEditIntervalMs({ VOICY_PROGRESS_EDIT_INTERVAL_MS: '4000' }) === 4000,
+  'valid configured progress edit interval should be used'
+)
+
+assert(
+  !shouldThrottleProgressPublish({ now: baseTime }),
+  'first progress publish should not be throttled'
+)
+assert(
+  shouldThrottleProgressPublish({
+    intervalMs: 2500,
+    lastPublishedAt: baseTime,
+    now: new Date(baseTime.getTime() + 1000),
+  }),
+  'progress publish inside edit interval should be throttled'
+)
+assert(
+  !shouldThrottleProgressPublish({
+    intervalMs: 2500,
+    lastPublishedAt: baseTime,
+    now: new Date(baseTime.getTime() + 2500),
+  }),
+  'progress publish at edit interval boundary should be allowed'
+)
+assert(
+  !shouldThrottleProgressPublish({
+    force: true,
+    intervalMs: 2500,
+    lastPublishedAt: baseTime,
+    now: new Date(baseTime.getTime() + 1000),
+  }),
+  'forced progress publish should bypass throttling'
+)
+
+assert(
+  liveProgressAllowedForChatType('private'),
+  'private chats should allow live progress edits'
+)
+assert(
+  liveProgressAllowedForChatType('group'),
+  'groups should allow live progress edits'
+)
+assert(
+  liveProgressAllowedForChatType('supergroup'),
+  'supergroups should allow live progress edits'
+)
+assert(
+  !liveProgressAllowedForChatType('channel'),
+  'channels should not use live progress edits'
+)
+
+console.log('progress policy proof passed')

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -79,6 +79,7 @@ async function enqueueTranscription(
     status: TranscriptionJobStatus.queued,
     chatId: ctx.dbchat.id,
     telegramChatId: String(ctx.chat.id),
+    telegramChatType: ctx.chat.type,
     sourceMessageId: sourceMessage.message_id,
     requestMessageId: ctx.msg?.message_id,
     fileId,
@@ -95,6 +96,11 @@ async function enqueueTranscription(
     forwardSenderName: sourceMessage.forward_sender_name,
     uiLocale: ctx.dbchat.uiLanguage,
   })
+
+  if (ctx.chat.type === 'channel') {
+    console.info('Skipping live transcription status message in channel chat')
+    return queuedJob
+  }
 
   try {
     const ackMessage = await ctx.reply(markdownI18n(ctx, 'initiated'), {

--- a/src/helpers/transcriptionJobs/progressPublishingPolicy.ts
+++ b/src/helpers/transcriptionJobs/progressPublishingPolicy.ts
@@ -1,0 +1,32 @@
+export const DEFAULT_PROGRESS_EDIT_INTERVAL_MS = 2500
+export const MIN_PROGRESS_EDIT_INTERVAL_MS = 1000
+
+export function progressEditIntervalMs(env: NodeJS.ProcessEnv = process.env) {
+  const configured = Number(env.VOICY_PROGRESS_EDIT_INTERVAL_MS)
+  if (!Number.isFinite(configured)) {
+    return DEFAULT_PROGRESS_EDIT_INTERVAL_MS
+  }
+  return Math.max(configured, MIN_PROGRESS_EDIT_INTERVAL_MS)
+}
+
+export function liveProgressAllowedForChatType(chatType?: string) {
+  return chatType !== 'channel'
+}
+
+export function shouldThrottleProgressPublish({
+  force = false,
+  intervalMs = progressEditIntervalMs(),
+  lastPublishedAt,
+  now = new Date(),
+}: {
+  force?: boolean
+  intervalMs?: number
+  lastPublishedAt?: Date
+  now?: Date
+}) {
+  if (force || !lastPublishedAt) {
+    return false
+  }
+
+  return now.getTime() - lastPublishedAt.getTime() < intervalMs
+}

--- a/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
+++ b/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
@@ -54,6 +54,11 @@ export default async function publishCompletedTranscriptionJob(
     job.uiLocale,
     'completed_empty'
   )
+  const replyOptions =
+    job.telegramChatType === 'channel'
+      ? {}
+      : { reply_to_message_id: job.sourceMessageId }
+
   if (job.statusMessageId) {
     await bot.api.editMessageText(
       job.telegramChatId,
@@ -62,13 +67,13 @@ export default async function publishCompletedTranscriptionJob(
     )
   } else {
     await bot.api.sendMessage(job.telegramChatId, firstText || fallbackText, {
-      reply_to_message_id: job.sourceMessageId,
+      ...replyOptions,
     })
   }
 
   for (const chunk of chunks) {
     await bot.api.sendMessage(job.telegramChatId, chunk, {
-      reply_to_message_id: job.sourceMessageId,
+      ...replyOptions,
     })
   }
 }

--- a/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
+++ b/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
@@ -1,32 +1,17 @@
 import { DocumentType } from '@typegoose/typegoose'
 import { TranscriptionJob } from '@/models/TranscriptionJob'
 import {
+  liveProgressAllowedForChatType,
+  shouldThrottleProgressPublish,
+} from '@/helpers/transcriptionJobs/progressPublishingPolicy'
+import {
   partialTranscriptText,
   progressPreview,
 } from '@/helpers/transcriptionJobs/transcriptFormatting'
 import bot from '@/helpers/bot'
 import localizedTranscriptionText from '@/helpers/localizedTranscriptionText'
 
-const DEFAULT_PROGRESS_EDIT_INTERVAL_MS = 2500
-
 type ProgressPhase = 'processing' | 'partial' | 'retrying' | 'failed'
-
-function progressEditIntervalMs() {
-  const configured = Number(process.env.VOICY_PROGRESS_EDIT_INTERVAL_MS)
-  return Number.isFinite(configured) && configured >= 1000
-    ? configured
-    : DEFAULT_PROGRESS_EDIT_INTERVAL_MS
-}
-
-function shouldThrottle(job: DocumentType<TranscriptionJob>, force: boolean) {
-  if (force || !job.lastProgressPublishedAt) {
-    return false
-  }
-  return (
-    new Date().getTime() - job.lastProgressPublishedAt.getTime() <
-    progressEditIntervalMs()
-  )
-}
 
 function statusText(phase: ProgressPhase, job: DocumentType<TranscriptionJob>) {
   if (phase === 'processing') {
@@ -58,7 +43,11 @@ export default async function publishTranscriptionJobProgress(
   if (
     process.env.VOICY_DISABLE_TELEGRAM_PUBLISH === '1' ||
     !job.statusMessageId ||
-    shouldThrottle(job, force)
+    !liveProgressAllowedForChatType(job.telegramChatType) ||
+    shouldThrottleProgressPublish({
+      force,
+      lastPublishedAt: job.lastProgressPublishedAt,
+    })
   ) {
     return false
   }

--- a/src/helpers/workerApi/jobService.ts
+++ b/src/helpers/workerApi/jobService.ts
@@ -137,6 +137,7 @@ export function serializeJob(job: DocumentType<TranscriptionJob>) {
     status: job.status,
     chatId: job.chatId,
     telegramChatId: job.telegramChatId,
+    telegramChatType: job.telegramChatType,
     sourceMessageId: job.sourceMessageId,
     statusMessageId: job.statusMessageId,
     requestMessageId: job.requestMessageId,

--- a/src/models/TranscriptionJob.ts
+++ b/src/models/TranscriptionJob.ts
@@ -52,6 +52,8 @@ export class TranscriptionJob {
   chatId: string
   @prop({ required: true })
   telegramChatId: string
+  @prop()
+  telegramChatType?: string
   @prop({ required: true })
   sourceMessageId: number
   @prop()


### PR DESCRIPTION
## Summary
- persist Telegram chat type on transcription jobs and disable live progress edits for channels
- factor Telegram progress edit throttling into a tested policy helper
- document the streaming progress worker/API contract and channel fallback behavior

## Testing
- [x] yarn build-ts
- [x] yarn lint
- [x] yarn test:progress-policy
- [x] yarn test:worker-client
- [x] MONGO=mongodb://127.0.0.1:27018/voicy_worker_proof yarn test:worker-api (temporary Docker Mongo container)

## Review guidance
- Automated checks cover TypeScript, lint, worker-client behavior, worker API persistence, and the edit-throttling/channel policy.
- Channel live-edit behavior is intentionally unverified and disabled; channel jobs skip the editable queued acknowledgement and publish only final text.
- Private/group Telegram live QA was not run in this workspace because the change is policy-level and no logged-in Telegram QA loop was needed here.