### PR TITLE
Expand Telegram media transcription coverage

### DIFF
--- a/docs/media-coverage.md
+++ b/docs/media-coverage.md
@@ -1,0 +1,40 @@
+# Voicy media transcription coverage
+
+Voicy queues Telegram media by file metadata and leaves format normalization to
+the worker host, where ffmpeg or other local tooling is expected to be
+available.
+
+## Telegram intake
+
+| Telegram surface | Queued | Notes |
+| --- | --- | --- |
+| Voice message | Yes | Native Telegram voice payload. |
+| Video note | Yes | Circular video messages are queued as `video_note`. |
+| Video message | Yes | Telegram `video` messages are queued as `video`. |
+| Audio message | Yes | Telegram `audio` messages are queued directly. |
+| Document upload | Yes, when media-like | Documents are accepted when MIME is audio/video, a known audio/video application MIME, a transcribable filename extension, or an unknown octet-stream without a filename. |
+| Non-media document | No | Documents such as PDF files are ignored by media intake. |
+
+## Container hints
+
+| Format/container | Intake signal | Worker filename hint |
+| --- | --- | --- |
+| Ogg/Opus | `audio/ogg`, `audio/opus`, `.ogg`, `.oga`, `.opus`, Telegram voice URL fallback | `.ogg` or `.opus` |
+| MP3/MPEG audio | `audio/mpeg`, `.mp3` | `.mp3` |
+| WAV | `audio/wav`, `audio/x-wav`, `.wav`, `.wave` | `.wav` |
+| M4A/AAC/MP4 audio | `audio/mp4`, `audio/aac`, `.m4a`, `.m4b`, `.aac` | `.m4a` or `.aac` |
+| FLAC | `audio/flac`, `.flac` | `.flac` |
+| WebM | `audio/webm`, `video/webm`, `.webm`, `.weba` | `.webm` |
+| MP4 video | `video/mp4`, `application/mp4`, `.mp4`, Telegram video/video-note fallback | `.mp4` |
+| MOV/QuickTime | `video/quicktime`, `.mov` | `.mov` |
+| MKV | `video/x-matroska`, `.mkv`, `.mka` | `.mkv` |
+| AVI | `video/x-msvideo`, `.avi` | `.avi` |
+| 3GP | `video/3gpp`, `.3gp`, `.3gpp` | `.3gp` |
+
+## Verified coverage
+
+Automated proof currently verifies media classification for Telegram audio,
+Telegram video, supported media documents, rejected PDF documents, and worker
+extension selection for FLAC, filename-derived WebM, and default Telegram video
+sources. Live Telegram client upload coverage should be recorded separately when
+run against a deployed bot and worker.

--- a/docs/voicy-vnext-queued-transcription-plan.md
+++ b/docs/voicy-vnext-queued-transcription-plan.md
@@ -331,8 +331,8 @@ MVP should treat streaming as optional but prepare the API:
 
 ## MVP Scope
 
-- Bot creates durable queued jobs for voice, video note, supported audio, and
-  supported document inputs.
+- Bot creates durable queued jobs for voice, video note, video, supported audio,
+  and supported document inputs.
 - Donation wall is preserved with compute-funding copy.
 - `/language` controls only bot UI language.
 - Engine selection and old provider credential commands are removed from active

--- a/docs/worker-api.md
+++ b/docs/worker-api.md
@@ -56,7 +56,7 @@ Returns metadata for a processing job owned by the authenticated worker.
 
 ### `GET /jobs/:id/source`
 
-Returns the source audio metadata and URL for a processing job owned by the
+Returns the source media metadata and URL for a processing job owned by the
 authenticated worker.
 
 ### `POST /jobs/:id/heartbeat`

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:worker-api": "node scripts/worker-api-proof.js",
     "test:language-selection": "node scripts/language-selection-proof.js",
     "test:progress-policy": "node scripts/progress-policy-proof.js",
+    "test:media-coverage": "node scripts/media-coverage-proof.js",
     "test:telegram-runtime": "node scripts/telegram-runtime-check.js",
     "test:local-runtime-health": "node scripts/local-runtime-health.js",
     "qa:telegram-upload": "node scripts/telegram-web-upload-qa.mjs",

--- a/scripts/media-coverage-proof.js
+++ b/scripts/media-coverage-proof.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+require('module-alias/register')
+
+const {
+  isTranscribableMimeType,
+  transcribableExtension,
+  transcribableMediaFromMessage,
+} = require('../dist/helpers/transcribableTelegramMedia')
+const { extensionForSource } = require('../dist/workerClient/runWindowsWorker')
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function assertMedia(message, sourceType, fileId) {
+  const media = transcribableMediaFromMessage(message)
+  assert(media, `${sourceType} should be transcribable`)
+  assert(media.sourceType === sourceType, `${sourceType} source type missing`)
+  assert(media.file_id === fileId, `${sourceType} file id missing`)
+}
+
+assert(isTranscribableMimeType('audio/flac'), 'FLAC MIME should be accepted')
+assert(
+  isTranscribableMimeType('video/mp4'),
+  'MP4 video MIME should be accepted'
+)
+assert(
+  isTranscribableMimeType('application/ogg'),
+  'application/ogg MIME should be accepted'
+)
+assert(
+  transcribableExtension('meeting-recording.m4a') === '.m4a',
+  'M4A extension should be accepted'
+)
+assert(!transcribableExtension('notes.pdf'), 'PDF extension should be rejected')
+
+assertMedia(
+  {
+    audio: { file_id: 'audio-file', mime_type: 'audio/mpeg' },
+  },
+  'audio',
+  'audio-file'
+)
+assertMedia(
+  {
+    video: { file_id: 'video-file', mime_type: 'video/mp4' },
+  },
+  'video',
+  'video-file'
+)
+assertMedia(
+  {
+    document: {
+      file_id: 'doc-file',
+      file_name: 'call-recording.opus',
+      mime_type: 'application/octet-stream',
+    },
+  },
+  'document',
+  'doc-file'
+)
+assert(
+  !transcribableMediaFromMessage({
+    document: {
+      file_id: 'pdf-file',
+      file_name: 'contract.pdf',
+      mime_type: 'application/pdf',
+    },
+  }),
+  'PDF documents should not be transcribable'
+)
+assert(
+  !transcribableMediaFromMessage({
+    document: {
+      file_id: 'octet-pdf-file',
+      file_name: 'contract.pdf',
+      mime_type: 'application/octet-stream',
+    },
+  }),
+  'octet-stream documents with unsupported extensions should not be transcribable'
+)
+
+assert(
+  extensionForSource({
+    sourceUrl: 'https://example.invalid/file',
+    mimeType: 'audio/flac',
+  }) === '.flac',
+  'worker should preserve FLAC extension from MIME'
+)
+assert(
+  extensionForSource({
+    sourceUrl: 'https://example.invalid/file',
+    mimeType: 'application/octet-stream',
+    fileName: 'telegram-upload.webm',
+  }) === '.webm',
+  'worker should preserve extension from Telegram file name'
+)
+assert(
+  extensionForSource({
+    sourceUrl: 'https://example.invalid/file',
+    sourceKind: 'video',
+  }) === '.mp4',
+  'worker should default video sources to mp4'
+)
+
+console.log('media coverage proof passed')

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,7 +55,7 @@ async function runApp() {
   bot.on('my_chat_member', handleMyChatMember)
   bot.on([':voice', ':video_note'], handleAudio)
   bot.on(
-    [':audio', ':document'],
+    [':audio', ':document', ':video'],
     checkFilesBanned,
     checkDocumentType,
     handleAudio

--- a/src/commands/handleTranscribe.ts
+++ b/src/commands/handleTranscribe.ts
@@ -1,5 +1,6 @@
 import { enqueueTranscription } from '@/handlers/handleAudio'
 import { markdownI18n } from '@/helpers/telegramMarkdown'
+import { transcribableMediaFromMessage } from '@/helpers/transcribableTelegramMedia'
 import Context from '@/models/Context'
 import fileUrl from '@/helpers/fileUrl'
 import report from '@/helpers/report'
@@ -23,8 +24,7 @@ export default async function handleTranscribe(ctx: Context) {
       return
     }
 
-    const voice =
-      message.voice || message.document || message.audio || message.video_note
+    const voice = transcribableMediaFromMessage(message)
 
     if (!voice) {
       await ctx.reply(ctx.i18n.t('reply_to_voice'), {

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -1,5 +1,9 @@
 import { Message } from '@grammyjs/types'
 import {
+  TranscribableTelegramFile,
+  transcribableMediaFromMessage,
+} from '@/helpers/transcribableTelegramMedia'
+import {
   TranscriptionJobModel,
   TranscriptionJobSourceKind,
   TranscriptionJobStatus,
@@ -8,15 +12,6 @@ import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
 import fileUrl from '@/helpers/fileUrl'
 import report from '@/helpers/report'
-
-type AudioPayload = {
-  file_id: string
-  file_size?: number
-  mime_type?: string
-  file_name?: string
-  file_unique_id?: string
-  sourceType: 'voice' | 'audio' | 'document' | 'video_note'
-}
 
 export default async function handleAudio(ctx: Context) {
   try {
@@ -37,7 +32,10 @@ export default async function handleAudio(ctx: Context) {
     }
 
     const message = ctx.msg
-    const audio = audioFromMessage(message)
+    const audio = transcribableMediaFromMessage(message)
+    if (!audio) {
+      return
+    }
     if (audio.file_size && audio.file_size >= 19 * 1024 * 1024) {
       if (!ctx.dbchat.silent) {
         await sendLargeFileError(ctx)
@@ -74,7 +72,10 @@ async function enqueueTranscription(
   sourceMessage: Message = ctx.msg,
   filePath?: string
 ) {
-  const audio = audioFromMessage(sourceMessage)
+  const audio = transcribableMediaFromMessage(sourceMessage)
+  if (!audio) {
+    throw new Error('No supported audio payload found on message')
+  }
   const queuedJob = await TranscriptionJobModel.create({
     status: TranscriptionJobStatus.queued,
     chatId: ctx.dbchat.id,
@@ -86,6 +87,7 @@ async function enqueueTranscription(
     filePath,
     fileSize: audio.file_size,
     mimeType: audio.mime_type,
+    fileName: audio.file_name,
     fileUniqueId: fileUniqueId(audio),
     sourceKind: sourceKind(audio.sourceType),
     sourceUrl: url,
@@ -121,31 +123,15 @@ async function enqueueTranscription(
   return queuedJob
 }
 
-function sourceKind(sourceType: AudioPayload['sourceType']) {
+function sourceKind(sourceType: TranscribableTelegramFile['sourceType']) {
   if (sourceType === 'video_note') {
     return TranscriptionJobSourceKind.videoNote
   }
   return sourceType as TranscriptionJobSourceKind
 }
 
-function fileUniqueId(audio: AudioPayload) {
+function fileUniqueId(audio: TranscribableTelegramFile) {
   return 'file_unique_id' in audio ? audio.file_unique_id : undefined
-}
-
-function audioFromMessage(message: Message): AudioPayload {
-  if (message.voice) {
-    return { ...message.voice, sourceType: 'voice' }
-  }
-  if (message.audio) {
-    return { ...message.audio, sourceType: 'audio' }
-  }
-  if (message.document) {
-    return { ...message.document, sourceType: 'document' }
-  }
-  if (message.video_note) {
-    return { ...message.video_note, sourceType: 'video_note' }
-  }
-  throw new Error('No supported audio payload found on message')
 }
 
 async function sendQueueError(ctx: Context) {

--- a/src/helpers/transcribableTelegramMedia.ts
+++ b/src/helpers/transcribableTelegramMedia.ts
@@ -1,0 +1,113 @@
+import { Message } from '@grammyjs/types'
+
+export type TranscribableTelegramSourceType =
+  | 'voice'
+  | 'audio'
+  | 'document'
+  | 'video_note'
+  | 'video'
+
+export type TranscribableTelegramFile = {
+  file_id: string
+  file_size?: number
+  mime_type?: string
+  file_name?: string
+  file_unique_id?: string
+  sourceType: TranscribableTelegramSourceType
+}
+
+const transcribableMimeTypes = new Set([
+  'application/mp4',
+  'application/ogg',
+  'application/x-mpegurl',
+  'application/x-ogg',
+  'application/vnd.apple.mpegurl',
+])
+
+const transcribableExtensions = new Set([
+  '.3gp',
+  '.3gpp',
+  '.aac',
+  '.aif',
+  '.aifc',
+  '.aiff',
+  '.amr',
+  '.avi',
+  '.flac',
+  '.m4a',
+  '.m4b',
+  '.m4v',
+  '.mka',
+  '.mkv',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.mpeg',
+  '.mpg',
+  '.oga',
+  '.ogg',
+  '.opus',
+  '.wav',
+  '.wave',
+  '.weba',
+  '.webm',
+  '.wma',
+])
+
+export function isTranscribableMimeType(mimeType?: string) {
+  const normalizedMimeType = mimeType?.toLowerCase().split(';')[0].trim()
+  if (!normalizedMimeType) {
+    return false
+  }
+  return (
+    normalizedMimeType.startsWith('audio/') ||
+    normalizedMimeType.startsWith('video/') ||
+    transcribableMimeTypes.has(normalizedMimeType)
+  )
+}
+
+export function transcribableExtension(fileName?: string) {
+  const match = fileName?.toLowerCase().match(/\.[a-z0-9]+$/)
+  if (!match) {
+    return undefined
+  }
+  return transcribableExtensions.has(match[0]) ? match[0] : undefined
+}
+
+export function isTranscribableTelegramFile(file: TranscribableTelegramFile) {
+  if (file.sourceType !== 'document') {
+    return true
+  }
+  if (transcribableExtension(file.file_name)) {
+    return true
+  }
+  if (
+    file.mime_type?.toLowerCase().split(';')[0].trim() ===
+    'application/octet-stream'
+  ) {
+    return !file.file_name
+  }
+  return isTranscribableMimeType(file.mime_type)
+}
+
+export function transcribableMediaFromMessage(
+  message: Message
+): TranscribableTelegramFile | undefined {
+  if (message.voice) {
+    return { ...message.voice, sourceType: 'voice' }
+  }
+  if (message.audio) {
+    return { ...message.audio, sourceType: 'audio' }
+  }
+  if (message.video_note) {
+    return { ...message.video_note, sourceType: 'video_note' }
+  }
+  if (message.video) {
+    return { ...message.video, sourceType: 'video' }
+  }
+  if (message.document) {
+    const document = { ...message.document, sourceType: 'document' as const }
+    return isTranscribableTelegramFile(document) ? document : undefined
+  }
+  return undefined
+}

--- a/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
+++ b/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
@@ -18,6 +18,7 @@ async function storeVoiceRecord(job: DocumentType<TranscriptionJob>) {
     fileId: job.fileId,
     fileSize: job.fileSize,
     mimeType: job.mimeType,
+    fileName: job.fileName,
     sourceType: job.sourceKind,
     requestedBy: job.requestedByUserId
       ? Number(job.requestedByUserId)

--- a/src/helpers/workerApi/jobService.ts
+++ b/src/helpers/workerApi/jobService.ts
@@ -146,6 +146,7 @@ export function serializeJob(job: DocumentType<TranscriptionJob>) {
     filePath: job.filePath,
     fileSize: job.fileSize,
     mimeType: job.mimeType,
+    fileName: job.fileName,
     sourceKind: job.sourceKind,
     sourceUrl: job.sourceUrl,
     requestedByUserId: job.requestedByUserId,

--- a/src/helpers/workerApi/router.ts
+++ b/src/helpers/workerApi/router.ts
@@ -69,6 +69,7 @@ workerRouter.get(
         filePath: job.filePath,
         fileSize: job.fileSize,
         mimeType: job.mimeType,
+        fileName: job.fileName,
         sourceKind: job.sourceKind,
         sourceUrl: job.sourceUrl,
       },

--- a/src/middlewares/checkDocumentType.ts
+++ b/src/middlewares/checkDocumentType.ts
@@ -1,16 +1,16 @@
 import { NextFunction } from 'grammy'
+import {
+  isTranscribableTelegramFile,
+  transcribableMediaFromMessage,
+} from '@/helpers/transcribableTelegramMedia'
 import Context from '@/models/Context'
 
 export default function checkDocumentType(ctx: Context, next: NextFunction) {
-  const file = ctx.msg?.document || ctx.msg?.audio
+  const file = ctx.msg ? transcribableMediaFromMessage(ctx.msg) : undefined
   if (!file) {
     return
   }
-  const mime = file.mime_type
-  const allowedMimeTypes = ['audio', 'octet-stream']
-  for (const allowedType of allowedMimeTypes) {
-    if (mime.includes(allowedType)) {
-      return next()
-    }
+  if (isTranscribableTelegramFile(file)) {
+    return next()
   }
 }

--- a/src/models/TranscriptionJob.ts
+++ b/src/models/TranscriptionJob.ts
@@ -19,6 +19,7 @@ export enum TranscriptionJobSourceKind {
   videoNote = 'video_note',
   audio = 'audio',
   document = 'document',
+  video = 'video',
 }
 
 export interface TranscriptionResultPart {
@@ -70,6 +71,8 @@ export class TranscriptionJob {
   fileSize?: number
   @prop()
   mimeType?: string
+  @prop()
+  fileName?: string
   @prop({ required: true, enum: TranscriptionJobSourceKind })
   sourceKind: TranscriptionJobSourceKind
   @prop({ required: true })

--- a/src/models/Voice.ts
+++ b/src/models/Voice.ts
@@ -33,7 +33,7 @@ export class Voice {
   @prop()
   fileName?: string
   @prop({ required: true })
-  sourceType: 'voice' | 'audio' | 'document' | 'video_note'
+  sourceType: 'voice' | 'audio' | 'document' | 'video_note' | 'video'
   @prop()
   requestedBy?: number
   @prop()

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -34,6 +34,7 @@ interface WorkerSource {
   sourceUrl: string
   sourceKind?: string
   mimeType?: string
+  fileName?: string
   fileId?: string
   fileUniqueId?: string
 }
@@ -179,17 +180,43 @@ async function getSource(api: AxiosInstance, jobId: string) {
   return (response.data as SourceResponse).source
 }
 
-function extensionForSource(source: WorkerSource) {
-  if (source.mimeType === 'audio/mpeg') {
-    return '.mp3'
+const extensionByMimeType: Record<string, string> = {
+  'audio/aac': '.aac',
+  'audio/aiff': '.aiff',
+  'audio/amr': '.amr',
+  'audio/flac': '.flac',
+  'audio/mp4': '.m4a',
+  'audio/mpeg': '.mp3',
+  'audio/ogg': '.ogg',
+  'audio/opus': '.opus',
+  'audio/wav': '.wav',
+  'audio/webm': '.webm',
+  'audio/x-aiff': '.aiff',
+  'audio/x-m4a': '.m4a',
+  'audio/x-ms-wma': '.wma',
+  'audio/x-wav': '.wav',
+  'video/3gpp': '.3gp',
+  'video/mp4': '.mp4',
+  'video/mpeg': '.mpeg',
+  'video/quicktime': '.mov',
+  'video/webm': '.webm',
+  'video/x-m4v': '.m4v',
+  'video/x-matroska': '.mkv',
+  'video/x-msvideo': '.avi',
+}
+
+export function extensionForSource(source: WorkerSource) {
+  const mimeType = source.mimeType?.toLowerCase().split(';')[0].trim()
+  if (mimeType && extensionByMimeType[mimeType]) {
+    return extensionByMimeType[mimeType]
   }
-  if (source.mimeType === 'audio/wav' || source.mimeType === 'audio/x-wav') {
-    return '.wav'
+  if (source.fileName) {
+    const fileNameExt = path.extname(source.fileName)
+    if (fileNameExt) {
+      return fileNameExt.toLowerCase()
+    }
   }
-  if (source.mimeType === 'audio/mp4') {
-    return '.m4a'
-  }
-  if (source.sourceKind === 'video_note') {
+  if (source.sourceKind === 'video_note' || source.sourceKind === 'video') {
     return '.mp4'
   }
   const urlPath = new URL(source.sourceUrl).pathname


### PR DESCRIPTION
## Summary
- Add shared Telegram media classification for voice, video notes, videos, audio, and supported media documents.
- Preserve Telegram `fileName` through transcription jobs, worker source responses, and completed Voice records.
- Extend worker source extension selection for common audio/video containers and document the coverage matrix in `docs/media-coverage.md`.
- Add `yarn test:media-coverage` proof for supported/rejected media classification and worker filename hints.

## Coverage Matrix
See `docs/media-coverage.md` for the full matrix.

Implemented intake surfaces:
- voice messages
- video notes / circular videos
- Telegram `video` messages
- Telegram `audio` messages
- media-like document uploads by MIME or filename extension

Automated proof verifies:
- Telegram audio classification
- Telegram video classification
- media document classification
- PDF and octet-stream PDF rejection
- worker extension hints for FLAC, filename-derived WebM, and video fallback

## Testing
- `yarn build-ts && yarn test:media-coverage && yarn test:worker-client && yarn lint`

## Review Guidance
The automated checks prove classification and worker filename-hint behavior only; I did not run live Telegram uploads in this branch. For manual QA, use the existing Telegram Web upload helper against a deployed bot/worker and test representative voice, video note, audio document, and video file inputs before claiming client-side coverage beyond the automated matrix.

Kaneo: VOI-KANEO-33
