### PR TITLE
Let workers download Telegram media locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,16 @@ $env:VOICY_WORKER_TOKEN = "voicy_worker_..."
 $env:VOICY_WORKER_WORK_DIR = "C:\voicy-worker\jobs"
 $env:VOICY_WORKER_ENGINE = "faster-whisper"
 $env:VOICY_WORKER_MODEL = "large-v3"
+$env:VOICY_WORKER_TELEGRAM_BOT_TOKEN = "<telegram-bot-token>"
+$env:VOICY_WORKER_TELEGRAM_API_URL = "http://127.0.0.1:8081"
+$env:VOICY_WORKER_DOWNLOAD_CONCURRENCY = "2"
+$env:VOICY_WORKER_TRANSCRIPTION_CONCURRENCY = "1"
 $env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language} {model}"
 yarn worker:run
 ```
+
+Set `VOICY_MAX_MEDIA_FILE_SIZE_MB` on the backend to tune the largest Telegram
+media message that Voicy will enqueue for local workers.
 
 See [`docs/windows-worker-client.md`](docs/windows-worker-client.md) for the
 full Windows setup, environment variables, retry behavior, and validation steps.

--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -142,8 +142,17 @@ $env:VOICY_WORKER_ENGINE = "faster-whisper"
 $env:VOICY_WORKER_MODEL = "large-v3"
 $env:VOICY_WORKER_HEARTBEAT_INTERVAL_MS = "30000"
 $env:VOICY_WORKER_POLL_INTERVAL_MS = "5000"
+$env:VOICY_WORKER_TELEGRAM_BOT_TOKEN = "<telegram-bot-token>"
+$env:VOICY_WORKER_TELEGRAM_API_URL = "http://127.0.0.1:8081"
+$env:VOICY_WORKER_DOWNLOAD_CONCURRENCY = "2"
+$env:VOICY_WORKER_TRANSCRIPTION_CONCURRENCY = "1"
 $env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language} {model}"
 ```
+
+`VOICY_WORKER_TELEGRAM_API_URL` may point at a worker-local Telegram Bot API
+server. Leave it unset to use `https://api.telegram.org`. The token is read from
+`VOICY_WORKER_TELEGRAM_BOT_TOKEN` or `TOKEN` on the worker host and is not
+persisted in queued job URLs.
 
 For CPU or smoke-test environments with the OpenAI Whisper CLI installed, use the checked-in adapter instead:
 
@@ -165,9 +174,14 @@ spawns `whisper`, which protects the local test worker from launchd's default
 Optional:
 
 - `VOICY_WORKER_LANGUAGE=en` forces a language when the queued job has no hint.
-- `VOICY_WORKER_IDLE_EXIT=1` processes at most one available job and exits,
-  useful for smoke tests or scheduled runs.
+- `VOICY_WORKER_IDLE_EXIT=1` processes one available batch and exits, useful for
+  smoke tests or scheduled runs.
 - `VOICY_WORKER_DOWNLOAD_TIMEOUT_MS=300000` controls audio download timeout.
+- `VOICY_WORKER_DOWNLOAD_CONCURRENCY=2` controls parallel media downloads.
+- `VOICY_WORKER_TRANSCRIPTION_CONCURRENCY=1` controls concurrent local STT
+  commands.
+- `VOICY_MAX_MEDIA_FILE_SIZE_MB=20` controls the bot-side accepted Telegram
+  media size before a job is queued; set it on the backend.
 
 Run the worker:
 
@@ -175,23 +189,31 @@ Run the worker:
 yarn worker:run
 ```
 
-For a one-job smoke test, add `VOICY_WORKER_IDLE_EXIT=1` before running the
-worker. The process exits after processing one available job, or exits
-immediately if no queued job is available.
+For a smoke test, add `VOICY_WORKER_IDLE_EXIT=1` before running the worker. The
+process exits after one available batch, or exits immediately if no queued job is
+available.
 
 ## Runtime Behavior
 
-The client polls `POST /jobs/claim`. If there is no work, it sleeps for
+The client polls `POST /jobs/claim-download`. If there is no work, it sleeps for
 `VOICY_WORKER_POLL_INTERVAL_MS`.
 
 For each claimed job it:
 
 1. Reads source metadata from `GET /jobs/:id/source`.
-2. Downloads `sourceUrl` into `VOICY_WORKER_WORK_DIR`.
-3. Starts heartbeat posts while local transcription runs.
-4. Runs `VOICY_WORKER_TRANSCRIBE_COMMAND`.
-5. Reads transcript JSON from `{output}` or plain text from stdout.
-6. Uploads the result to `POST /jobs/:id/result`.
+2. Resolves Telegram `fileId`/`filePath` through the configured Telegram Bot API
+   endpoint when no legacy `sourceUrl` is present.
+3. Downloads the media into `VOICY_WORKER_WORK_DIR`.
+4. Marks the job `ready` with `POST /jobs/:id/downloaded`.
+5. Starts transcription with `POST /jobs/:id/transcribe`.
+6. Runs `VOICY_WORKER_TRANSCRIBE_COMMAND`.
+7. Reads transcript JSON from `{output}` or plain text from stdout.
+8. Uploads the result to `POST /jobs/:id/result`.
+
+Downloads run up to `VOICY_WORKER_DOWNLOAD_CONCURRENCY` in parallel. The
+transcription scheduler consumes whichever download becomes ready first, so a
+large slow file does not block a later smaller file that has already reached
+local disk.
 
 The command template supports `{input}`, `{output}`, `{language}`, and
 `{model}`. Paths and values are quoted before replacement so spaces in Windows
@@ -208,7 +230,8 @@ payloads and throttles visible Telegram edits server-side.
 
 Download failures, command crashes, and upload failures are reported to
 `POST /jobs/:id/failure` with `retryable: true`. The backend requeues retryable
-jobs until `VOICY_WORKER_MAX_ATTEMPTS` is reached, then marks them failed.
+jobs for download until `VOICY_WORKER_MAX_ATTEMPTS` is reached, then marks them
+failed.
 
 If the transcription command exits successfully but produces no transcript text,
 the client reports a non-retryable failure. That avoids repeatedly processing a
@@ -230,7 +253,8 @@ MONGO=mongodb://127.0.0.1:27017/voicy_worker_proof yarn test:worker-e2e
 
 `yarn test:worker-client` runs the compiled client against a mock worker API,
 downloads a fake audio payload, executes a fake transcriber, uploads the result,
-checks the no-work polling path, and checks retryable command failure reporting.
+checks the no-work polling path, checks retryable command failure reporting, and
+proves a smaller ready download can transcribe before a slower earlier download.
 
 `yarn test:worker-e2e` uses the real Express worker API, local Mongo, a queued
 `TranscriptionJob`, a local sample-audio HTTP server, and the worker client. It

--- a/docs/worker-api.md
+++ b/docs/worker-api.md
@@ -26,10 +26,11 @@ the jobs they own.
 
 All endpoints are mounted under `/worker/v1`.
 
-### `POST /jobs/claim`
+### `POST /jobs/claim-download`
 
-Atomically claims the oldest queued job for the authenticated worker. Returns
-`204` when no work is available.
+Atomically claims the oldest `queued_for_download` job for the authenticated
+worker. Legacy `queued` jobs are also accepted for migration. Returns `204`
+when no download work is available.
 
 Successful response:
 
@@ -37,8 +38,7 @@ Successful response:
 {
   "job": {
     "id": "665...",
-    "status": "processing",
-    "sourceUrl": "https://api.telegram.org/file/...",
+    "status": "downloading",
     "sourceKind": "voice",
     "fileId": "AwAC...",
     "attempts": 1
@@ -46,26 +46,71 @@ Successful response:
 }
 ```
 
-The Mongo update filters on `status: queued` and sets `status: processing`,
-`workerId`, `claimedAt`, and `heartbeatAt` in one `findOneAndUpdate`, so two
-workers cannot claim the same queued job.
-
-### `GET /jobs/:id`
-
-Returns metadata for a processing job owned by the authenticated worker.
+The Mongo update sets `status: downloading`, `workerId`, `claimedAt`,
+`heartbeatAt`, and increments `attempts` in one `findOneAndUpdate`, so two
+workers cannot claim the same media acquisition job.
 
 ### `GET /jobs/:id/source`
 
-Returns the source media metadata and URL for a processing job owned by the
-authenticated worker.
+Returns source media metadata for an owned `downloading`, `ready`,
+`transcribing`, or legacy `processing` job. New jobs expose Telegram `fileId`
+and any known `filePath`; workers resolve and download the media locally instead
+of relying on a bot-token-bearing persisted `sourceUrl`.
+
+```json
+{
+  "source": {
+    "jobId": "665...",
+    "fileId": "AwAC...",
+    "filePath": "voice/file_1.oga",
+    "fileSize": 12345,
+    "mimeType": "audio/ogg",
+    "sourceKind": "voice"
+  }
+}
+```
+
+### `POST /jobs/:id/downloaded`
+
+Marks an owned `downloading` job as `ready` after the worker has fully downloaded
+the Telegram media to local disk.
+
+```json
+{
+  "localSourcePath": "C:\\voicy-worker\\jobs\\665.ogg"
+}
+```
+
+### `POST /jobs/:id/transcribe`
+
+Marks an owned `ready` job as `transcribing`. Workers should call this only
+after the local media file is fully available.
+
+### `POST /jobs/claim-ready`
+
+Claims the oldest ready local file owned by the authenticated worker and marks
+it `transcribing`. This endpoint is available for split downloader/transcriber
+clients; the bundled worker normally calls `POST /jobs/:id/transcribe` for the
+job it just downloaded.
+
+### `POST /jobs/claim`
+
+Backward-compatible transcription claim endpoint. It first claims an owned
+`ready` job, then falls back to legacy `queued` jobs that still have a
+`sourceUrl`. New workers should prefer `claim-download`.
+
+### `GET /jobs/:id`
+
+Returns metadata for an active job owned by the authenticated worker.
 
 ### `POST /jobs/:id/heartbeat`
 
-Refreshes `heartbeatAt` for a processing job owned by the authenticated worker.
+Refreshes `heartbeatAt` for a `downloading`, `ready`, `transcribing`, or legacy
+`processing` job owned by the authenticated worker.
 
 ### `POST /jobs/:id/progress`
 
-Stores a partial transcript for a processing job owned by the authenticated
+Stores a partial transcript for a `transcribing` job owned by the authenticated
 worker and edits the bot's in-chat status message when enough time has passed
 since the last visible progress edit.
 
@@ -92,7 +137,7 @@ channel edit behavior is explicitly verified.
 
 ### `POST /jobs/:id/result`
 
-Completes a processing job owned by the authenticated worker, stores transcript
+Completes a `transcribing` job owned by the authenticated worker, stores transcript
 data, creates a legacy `Voice` record, and publishes the final transcript by
 editing the status/progress message unless `VOICY_DISABLE_TELEGRAM_PUBLISH=1`.
 Long final transcripts are split into follow-up replies after the first edited
@@ -131,8 +176,9 @@ Request body:
 `yarn test:worker-api` runs a scripted HTTP proof against `MONGO`. It verifies:
 
 - missing authentication returns `401`;
-- exactly one of two clients can claim a single queued job;
+- exactly one of two clients can claim a single queued download job;
 - a non-owning client cannot heartbeat another worker's job;
+- downloaded media moves the job to `ready` before transcription;
 - progress upload stores partial transcript state for the owning worker;
 - progress edit policy throttles rapid visible edits and disables live edits in
   channels;

--- a/scripts/local-whisper-worker-proof.js
+++ b/scripts/local-whisper-worker-proof.js
@@ -82,6 +82,8 @@ async function createSampleAudio(workDir) {
 function createProofServer(sampleAudio) {
   const state = {
     claimed: false,
+    downloaded: false,
+    transcribing: false,
     result: undefined,
     failure: undefined,
     audioAuthorization: undefined,
@@ -100,7 +102,10 @@ function createProofServer(sampleAudio) {
     }
 
     const token = request.headers.authorization
-    if (token !== 'Bearer local-whisper-proof-token') {
+    if (
+      url.pathname !== '/audio.wav' &&
+      token !== 'Bearer local-whisper-proof-token'
+    ) {
       response.writeHead(401, { 'Content-Type': 'application/json' })
       response.end(JSON.stringify({ error: 'invalid_worker_token' }))
       return
@@ -130,6 +135,32 @@ function createProofServer(sampleAudio) {
     }
 
     if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/claim-download'
+    ) {
+      if (state.claimed) {
+        response.writeHead(204)
+        response.end()
+        return
+      }
+      state.claimed = true
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id: 'local-whisper-proof-job',
+            status: 'downloading',
+            sourceKind: 'voice',
+            mimeType: 'audio/wav',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    if (
       request.method === 'GET' &&
       url.pathname === '/worker/v1/jobs/local-whisper-proof-job/source'
     ) {
@@ -141,6 +172,48 @@ function createProofServer(sampleAudio) {
             sourceKind: 'voice',
             mimeType: 'audio/wav',
             fileId: 'local-whisper-proof-file',
+          },
+        })
+      )
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/local-whisper-proof-job/downloaded'
+    ) {
+      state.downloaded = true
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id: 'local-whisper-proof-job',
+            status: 'ready',
+            sourceKind: 'voice',
+            mimeType: 'audio/wav',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/local-whisper-proof-job/transcribe'
+    ) {
+      state.transcribing = true
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id: 'local-whisper-proof-job',
+            status: 'transcribing',
+            sourceKind: 'voice',
+            mimeType: 'audio/wav',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
           },
         })
       )

--- a/scripts/worker-api-proof.js
+++ b/scripts/worker-api-proof.js
@@ -80,14 +80,17 @@ async function main() {
   const baseUrl = `http://127.0.0.1:${server.address().port}/worker/v1`
 
   try {
-    const unauthenticated = await request(baseUrl, '/jobs/claim', undefined, {
-      method: 'POST',
-    })
+    const unauthenticated = await request(
+      baseUrl,
+      '/jobs/claim-download',
+      undefined,
+      { method: 'POST' }
+    )
     assert(unauthenticated.status === 401, 'unauthenticated claim should fail')
 
     const [claimA, claimB] = await Promise.all([
-      request(baseUrl, '/jobs/claim', tokenA, { method: 'POST' }),
-      request(baseUrl, '/jobs/claim', tokenB, { method: 'POST' }),
+      request(baseUrl, '/jobs/claim-download', tokenA, { method: 'POST' }),
+      request(baseUrl, '/jobs/claim-download', tokenB, { method: 'POST' }),
     ])
     const claimStatuses = [claimA.status, claimB.status].sort().join(',')
     assert(
@@ -100,9 +103,16 @@ async function main() {
     const otherToken = claimA.status === 200 ? tokenB : tokenA
     const { job } = await claimedResponse.json()
     assert(job.id === queuedJob._id.toString(), 'claimed unexpected job')
-    assert(job.status === TranscriptionJobStatus.processing, 'job not processing')
+    assert(
+      job.status === TranscriptionJobStatus.downloading,
+      'job not downloading'
+    )
 
-    const source = await request(baseUrl, `/jobs/${job.id}/source`, claimedToken)
+    const source = await request(
+      baseUrl,
+      `/jobs/${job.id}/source`,
+      claimedToken
+    )
     assert(source.status === 200, 'owning worker should read job source')
 
     const stolenHeartbeat = await request(
@@ -112,6 +122,33 @@ async function main() {
       { method: 'POST' }
     )
     assert(stolenHeartbeat.status === 404, 'other worker should not heartbeat')
+
+    const downloaded = await request(
+      baseUrl,
+      `/jobs/${job.id}/downloaded`,
+      claimedToken,
+      {
+        method: 'POST',
+        body: JSON.stringify({ localSourcePath: '/tmp/proof-file-1.ogg' }),
+      }
+    )
+    assert(downloaded.status === 200, 'owning worker should mark downloaded')
+    const readyJob = await TranscriptionJobModel.findById(job.id)
+    assert(
+      readyJob.status === TranscriptionJobStatus.ready,
+      'downloaded job should become ready'
+    )
+
+    const transcribe = await request(
+      baseUrl,
+      `/jobs/${job.id}/transcribe`,
+      claimedToken,
+      { method: 'POST' }
+    )
+    assert(
+      transcribe.status === 200,
+      'owning worker should start transcription'
+    )
 
     const progress = await request(
       baseUrl,
@@ -136,23 +173,31 @@ async function main() {
     )
     assert(progressedJob.lastProgressAt, 'progress timestamp missing')
 
-    const result = await request(baseUrl, `/jobs/${job.id}/result`, claimedToken, {
-      method: 'POST',
-      body: JSON.stringify({
-        text: 'proof transcript',
-        parts: [{ timeCode: '00:00', text: 'proof transcript' }],
-        language: 'en',
-        engine: 'proof-engine',
-        duration: 1.2,
-      }),
-    })
+    const result = await request(
+      baseUrl,
+      `/jobs/${job.id}/result`,
+      claimedToken,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          text: 'proof transcript',
+          parts: [{ timeCode: '00:00', text: 'proof transcript' }],
+          language: 'en',
+          engine: 'proof-engine',
+          duration: 1.2,
+        }),
+      }
+    )
     assert(result.status === 200, 'owning worker should submit result')
     const completedJob = await TranscriptionJobModel.findById(job.id)
     assert(
       completedJob.status === TranscriptionJobStatus.completed,
       'result upload should complete job'
     )
-    assert(completedJob.resultText === 'proof transcript', 'result text missing')
+    assert(
+      completedJob.resultText === 'proof transcript',
+      'result text missing'
+    )
 
     const retryJob = await TranscriptionJobModel.create({
       chatId: 'proof-chat',
@@ -162,22 +207,28 @@ async function main() {
       sourceKind: TranscriptionJobSourceKind.voice,
       sourceUrl: 'https://example.invalid/proof-2.ogg',
     })
-    const claimRetry = await request(baseUrl, '/jobs/claim', tokenA, {
+    const claimRetry = await request(baseUrl, '/jobs/claim-download', tokenA, {
       method: 'POST',
     })
     assert(claimRetry.status === 200, 'second job should be claimable')
     const retryClaim = await claimRetry.json()
-    assert(retryClaim.job.id === retryJob._id.toString(), 'claimed wrong retry job')
+    assert(
+      retryClaim.job.id === retryJob._id.toString(),
+      'claimed wrong retry job'
+    )
     const failure = await request(
       baseUrl,
       `/jobs/${retryClaim.job.id}/failure`,
       tokenA,
-      { method: 'POST', body: JSON.stringify({ error: 'temporary', retryable: true }) }
+      {
+        method: 'POST',
+        body: JSON.stringify({ error: 'temporary', retryable: true }),
+      }
     )
     assert(failure.status === 200, 'retryable failure should be accepted')
     const requeuedJob = await TranscriptionJobModel.findById(retryClaim.job.id)
     assert(
-      requeuedJob.status === TranscriptionJobStatus.queued,
+      requeuedJob.status === TranscriptionJobStatus.queuedForDownload,
       'retryable failure should requeue below max attempts'
     )
 

--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -6,6 +6,7 @@ const path = require('path')
 
 const {
   loadConfig,
+  processAvailableJobs,
   processNextJob,
 } = require('../dist/workerClient/runWindowsWorker')
 
@@ -37,6 +38,8 @@ function readJson(request) {
 function createProofServer() {
   const state = {
     claimed: false,
+    downloaded: false,
+    transcribing: false,
     result: undefined,
     failure: undefined,
     heartbeats: 0,
@@ -53,7 +56,10 @@ function createProofServer() {
     }
 
     const token = request.headers.authorization
-    if (token !== 'Bearer proof-worker-token') {
+    const publicMediaPath =
+      url.pathname.startsWith('/botproof-telegram-token/') ||
+      url.pathname.startsWith('/file/botproof-telegram-token/')
+    if (!publicMediaPath && token !== 'Bearer proof-worker-token') {
       response.writeHead(401, { 'Content-Type': 'application/json' })
       response.end(JSON.stringify({ error: 'invalid_worker_token' }))
       return
@@ -82,6 +88,31 @@ function createProofServer() {
     }
 
     if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/claim-download'
+    ) {
+      if (state.claimed) {
+        response.writeHead(204)
+        response.end()
+        return
+      }
+      state.claimed = true
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id: 'proof-job',
+            status: 'downloading',
+            sourceKind: 'voice',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    if (
       request.method === 'GET' &&
       url.pathname === '/worker/v1/jobs/proof-job/source'
     ) {
@@ -89,12 +120,73 @@ function createProofServer() {
       response.end(
         JSON.stringify({
           source: {
-            sourceUrl: `http://127.0.0.1:${
-              server.address().port
-            }/audio/proof.ogg`,
             sourceKind: 'voice',
             mimeType: 'audio/ogg',
             fileId: 'proof-file',
+          },
+        })
+      )
+      return
+    }
+
+    if (
+      request.method === 'GET' &&
+      url.pathname === '/botproof-telegram-token/getFile'
+    ) {
+      assert(
+        url.searchParams.get('file_id') === 'proof-file',
+        'worker should resolve the Telegram file id locally'
+      )
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({ ok: true, result: { file_path: 'audio/proof.ogg' } })
+      )
+      return
+    }
+
+    if (
+      request.method === 'GET' &&
+      url.pathname === '/file/botproof-telegram-token/audio/proof.ogg'
+    ) {
+      response.writeHead(200, { 'Content-Type': 'audio/ogg' })
+      response.end(Buffer.from('proof audio bytes'))
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/proof-job/downloaded'
+    ) {
+      state.downloaded = await readJson(request)
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id: 'proof-job',
+            status: 'ready',
+            sourceKind: 'voice',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/proof-job/transcribe'
+    ) {
+      state.transcribing = true
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id: 'proof-job',
+            status: 'transcribing',
+            sourceKind: 'voice',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
           },
         })
       )
@@ -154,6 +246,166 @@ function close(server) {
   })
 }
 
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function createSchedulingProofServer() {
+  const queue = ['slow-job', 'small-job']
+  const state = {
+    transcribeOrder: [],
+    results: [],
+  }
+
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url, 'http://127.0.0.1')
+    if (
+      !url.pathname.startsWith('/audio/') &&
+      request.headers.authorization !== 'Bearer proof-worker-token'
+    ) {
+      response.writeHead(401, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify({ error: 'invalid_worker_token' }))
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/claim-download'
+    ) {
+      const id = queue.shift()
+      if (!id) {
+        response.writeHead(204)
+        response.end()
+        return
+      }
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id,
+            status: 'downloading',
+            sourceKind: 'voice',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    const sourceMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/source$/
+    )
+    if (request.method === 'GET' && sourceMatch) {
+      const id = sourceMatch[1]
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          source: {
+            sourceUrl: `http://127.0.0.1:${
+              server.address().port
+            }/audio/${id}.ogg`,
+            sourceKind: 'voice',
+            mimeType: 'audio/ogg',
+            fileId: id,
+          },
+        })
+      )
+      return
+    }
+
+    const audioMatch = url.pathname.match(/^\/audio\/([^/]+)\.ogg$/)
+    if (request.method === 'GET' && audioMatch) {
+      if (audioMatch[1] === 'slow-job') {
+        await delay(200)
+      }
+      response.writeHead(200, { 'Content-Type': 'audio/ogg' })
+      response.end(Buffer.from(`${audioMatch[1]} audio bytes`))
+      return
+    }
+
+    const downloadedMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/downloaded$/
+    )
+    if (request.method === 'POST' && downloadedMatch) {
+      const id = downloadedMatch[1]
+      await readJson(request)
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id,
+            status: 'ready',
+            sourceKind: 'voice',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    const transcribeMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/transcribe$/
+    )
+    if (request.method === 'POST' && transcribeMatch) {
+      const id = transcribeMatch[1]
+      state.transcribeOrder.push(id)
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id,
+            status: 'transcribing',
+            sourceKind: 'voice',
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    const resultMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/result$/
+    )
+    if (request.method === 'POST' && resultMatch) {
+      state.results.push(resultMatch[1])
+      await readJson(request)
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({ job: { id: resultMatch[1], status: 'completed' } })
+      )
+      return
+    }
+
+    const heartbeatMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/heartbeat$/
+    )
+    if (request.method === 'POST' && heartbeatMatch) {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify({ job: { id: heartbeatMatch[1] } }))
+      return
+    }
+
+    const failureMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/failure$/
+    )
+    if (request.method === 'POST' && failureMatch) {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({ job: { id: failureMatch[1], status: 'failed' } })
+      )
+      return
+    }
+
+    response.writeHead(404, { 'Content-Type': 'application/json' })
+    response.end(JSON.stringify({ error: 'not_found' }))
+  })
+
+  return { server, state }
+}
+
 async function main() {
   const { server, state } = createProofServer()
   await listen(server)
@@ -172,6 +424,10 @@ async function main() {
       VOICY_WORKER_IDLE_EXIT: '1',
       VOICY_WORKER_ENGINE: 'proof-engine',
       VOICY_WORKER_MODEL: 'proof-model',
+      VOICY_WORKER_TELEGRAM_API_URL: `http://127.0.0.1:${
+        server.address().port
+      }`,
+      VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
     }
     const config = loadConfig(env)
     const processed = await processNextJob(config, {
@@ -182,6 +438,11 @@ async function main() {
 
     assert(processed, 'worker should process the claimed job')
     assert(!state.failure, 'worker should not report failure')
+    assert(state.downloaded, 'worker should mark media downloaded before STT')
+    assert(
+      state.transcribing,
+      'worker should start transcription after download'
+    )
     assert(state.result, 'worker should submit a result')
     assert(
       state.result.text === 'fake transcript from worker client proof',
@@ -227,6 +488,10 @@ async function main() {
         os.tmpdir(),
         `voicy-worker-failure-proof-${process.pid}`
       ),
+      VOICY_WORKER_TELEGRAM_API_URL: `http://127.0.0.1:${
+        failureProof.server.address().port
+      }`,
+      VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
     })
 
     const processed = await processNextJob(config, {
@@ -247,6 +512,46 @@ async function main() {
     )
   } finally {
     await close(failureProof.server)
+  }
+
+  const schedulingProof = createSchedulingProofServer()
+  await listen(schedulingProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      schedulingProof.server.address().port
+    }/worker/v1`
+    const processed = await processAvailableJobs(
+      loadConfig({
+        VOICY_WORKER_API_URL: baseUrl,
+        VOICY_WORKER_TOKEN: 'proof-worker-token',
+        VOICY_WORKER_TRANSCRIBE_COMMAND:
+          'node scripts/fake-transcriber.js {input} {output}',
+        VOICY_WORKER_WORK_DIR: path.join(
+          os.tmpdir(),
+          `voicy-worker-scheduling-proof-${process.pid}`
+        ),
+        VOICY_WORKER_DOWNLOAD_CONCURRENCY: '2',
+        VOICY_WORKER_TRANSCRIPTION_CONCURRENCY: '1',
+      }),
+      {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      }
+    )
+
+    assert(processed === 2, 'scheduler should process both claimed jobs')
+    assert(
+      schedulingProof.state.transcribeOrder[0] === 'small-job',
+      'small downloaded job should transcribe before slow large download'
+    )
+    assert(
+      schedulingProof.state.results.length === 2,
+      'scheduler should upload both results'
+    )
+  } finally {
+    await close(schedulingProof.server)
   }
 
   console.log('worker client proof passed')

--- a/src/commands/handleTranscribe.ts
+++ b/src/commands/handleTranscribe.ts
@@ -1,8 +1,7 @@
-import { enqueueTranscription } from '@/handlers/handleAudio'
+import { enqueueTranscription, isMediaTooLarge } from '@/handlers/handleAudio'
 import { markdownI18n } from '@/helpers/telegramMarkdown'
 import { transcribableMediaFromMessage } from '@/helpers/transcribableTelegramMedia'
 import Context from '@/models/Context'
-import fileUrl from '@/helpers/fileUrl'
 import report from '@/helpers/report'
 
 export default async function handleTranscribe(ctx: Context) {
@@ -34,7 +33,7 @@ export default async function handleTranscribe(ctx: Context) {
     }
 
     // Check size
-    if (voice.file_size && voice.file_size >= 19 * 1024 * 1024) {
+    if (isMediaTooLarge(voice.file_size)) {
       if (!ctx.dbchat.silent) {
         await ctx.reply(markdownI18n(ctx, 'error_twenty'), {
           parse_mode: 'Markdown',
@@ -43,17 +42,7 @@ export default async function handleTranscribe(ctx: Context) {
       }
       return
     }
-    // Get full url to the voice message
-    const fileData = await ctx.api.getFile(voice.file_id)
-    const voiceUrl = fileUrl(fileData.file_path)
-
-    await enqueueTranscription(
-      ctx,
-      voiceUrl,
-      voice.file_id,
-      message,
-      fileData.file_path
-    )
+    await enqueueTranscription(ctx, voice.file_id, message)
   } catch (error) {
     report(error, { ctx, location: 'handleTranscribe' })
     await ctx.reply(markdownI18n(ctx, 'error_queue'), {

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -10,7 +10,6 @@ import {
 } from '@/models/TranscriptionJob'
 import { markdownI18n } from '@/helpers/telegramMarkdown'
 import Context from '@/models/Context'
-import fileUrl from '@/helpers/fileUrl'
 import report from '@/helpers/report'
 
 export default async function handleAudio(ctx: Context) {
@@ -36,22 +35,14 @@ export default async function handleAudio(ctx: Context) {
     if (!audio) {
       return
     }
-    if (audio.file_size && audio.file_size >= 19 * 1024 * 1024) {
+    if (isMediaTooLarge(audio.file_size)) {
       if (!ctx.dbchat.silent) {
         await sendLargeFileError(ctx)
       }
       return
     }
 
-    const fileData = await ctx.getFile()
-    const voiceUrl = fileUrl(fileData.file_path)
-    await enqueueTranscription(
-      ctx,
-      voiceUrl,
-      audio.file_id,
-      message,
-      fileData.file_path
-    )
+    await enqueueTranscription(ctx, audio.file_id, message)
   } catch (error) {
     report(error, { ctx, location: 'handleMessage' })
     await sendQueueError(ctx)
@@ -65,9 +56,21 @@ function sendLargeFileError(ctx: Context) {
   })
 }
 
+function maxMediaFileSizeBytes() {
+  const configuredMb = Number(process.env.VOICY_MAX_MEDIA_FILE_SIZE_MB || 20)
+  if (!Number.isFinite(configuredMb) || configuredMb <= 0) {
+    return undefined
+  }
+  return configuredMb * 1024 * 1024
+}
+
+function isMediaTooLarge(fileSize?: number) {
+  const limit = maxMediaFileSizeBytes()
+  return Boolean(limit && fileSize && fileSize >= limit)
+}
+
 async function enqueueTranscription(
   ctx: Context,
-  url: string,
   fileId: string,
   sourceMessage: Message = ctx.msg,
   filePath?: string
@@ -77,7 +80,7 @@ async function enqueueTranscription(
     throw new Error('No supported audio payload found on message')
   }
   const queuedJob = await TranscriptionJobModel.create({
-    status: TranscriptionJobStatus.queued,
+    status: TranscriptionJobStatus.queuedForDownload,
     chatId: ctx.dbchat.id,
     telegramChatId: String(ctx.chat.id),
     telegramChatType: ctx.chat.type,
@@ -90,7 +93,6 @@ async function enqueueTranscription(
     fileName: audio.file_name,
     fileUniqueId: fileUniqueId(audio),
     sourceKind: sourceKind(audio.sourceType),
-    sourceUrl: url,
     requestedByUserId: ctx.from?.id ? String(ctx.from.id) : undefined,
     forwardedFromUserId: sourceMessage.forward_from?.id
       ? String(sourceMessage.forward_from.id)
@@ -145,4 +147,4 @@ async function sendQueueError(ctx: Context) {
   }
 }
 
-export { enqueueTranscription }
+export { enqueueTranscription, isMediaTooLarge }

--- a/src/helpers/fileUrl.ts
+++ b/src/helpers/fileUrl.ts
@@ -1,7 +1,0 @@
-import { escape } from 'querystring'
-
-export default function fileUrl(filePath: string) {
-  return `https://api.telegram.org/file/bot${process.env.TOKEN}/${escape(
-    filePath
-  )}`
-}

--- a/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
+++ b/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
@@ -10,7 +10,7 @@ import localizedTranscriptionText from '@/helpers/localizedTranscriptionText'
 
 async function storeVoiceRecord(job: DocumentType<TranscriptionJob>) {
   await VoiceModel.create({
-    url: job.sourceUrl,
+    url: job.sourceUrl || job.localSourcePath || job.filePath || job.fileId,
     status: 'completed',
     chatId: job.chatId,
     messageId: job.sourceMessageId,

--- a/src/helpers/workerApi/jobService.ts
+++ b/src/helpers/workerApi/jobService.ts
@@ -144,6 +144,7 @@ export function serializeJob(job: DocumentType<TranscriptionJob>) {
     fileId: job.fileId,
     fileUniqueId: job.fileUniqueId,
     filePath: job.filePath,
+    localSourcePath: job.localSourcePath,
     fileSize: job.fileSize,
     mimeType: job.mimeType,
     fileName: job.fileName,
@@ -158,19 +159,29 @@ export function serializeJob(job: DocumentType<TranscriptionJob>) {
     lastProgressPublishedAt: job.lastProgressPublishedAt,
     attempts: job.attempts,
     claimedAt: job.claimedAt,
+    downloadedAt: job.downloadedAt,
     heartbeatAt: job.heartbeatAt,
     createdAt: timestampedJob.createdAt,
     updatedAt: timestampedJob.updatedAt,
   }
 }
 
-export async function claimNextJob(workerClient: DocumentType<WorkerClient>) {
+export async function claimDownloadJob(
+  workerClient: DocumentType<WorkerClient>
+) {
   const now = new Date()
   const job = await TranscriptionJobModel.findOneAndUpdate(
-    { status: TranscriptionJobStatus.queued },
+    {
+      status: {
+        $in: [
+          TranscriptionJobStatus.queuedForDownload,
+          TranscriptionJobStatus.queued,
+        ],
+      },
+    },
     {
       $set: {
-        status: TranscriptionJobStatus.processing,
+        status: TranscriptionJobStatus.downloading,
         workerId: workerId(workerClient),
         claimedAt: now,
         heartbeatAt: now,
@@ -185,11 +196,138 @@ export async function claimNextJob(workerClient: DocumentType<WorkerClient>) {
       { _id: workerClient._id },
       { $set: { lastClaimedAt: now } }
     )
+  }
+
+  return job
+}
+
+export async function claimReadyJob(workerClient: DocumentType<WorkerClient>) {
+  const now = new Date()
+  const job = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      workerId: workerId(workerClient),
+      status: TranscriptionJobStatus.ready,
+      localSourcePath: { $exists: true, $ne: '' },
+    },
+    {
+      $set: {
+        status: TranscriptionJobStatus.transcribing,
+        heartbeatAt: now,
+      },
+    },
+    { sort: { downloadedAt: 1, createdAt: 1 }, new: true }
+  )
+
+  if (job) {
     publishTranscriptionJobProgress(job, 'processing').catch((error) =>
       console.error('Failed to publish transcription job start', error)
     )
   }
 
+  return job
+}
+
+export async function startTranscriptionJob(
+  jobId: string,
+  workerClient: DocumentType<WorkerClient>
+) {
+  assertObjectId(jobId)
+  const now = new Date()
+  const job = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      _id: jobId,
+      workerId: workerId(workerClient),
+      status: TranscriptionJobStatus.ready,
+      localSourcePath: { $exists: true, $ne: '' },
+    },
+    {
+      $set: {
+        status: TranscriptionJobStatus.transcribing,
+        heartbeatAt: now,
+      },
+    },
+    { new: true }
+  )
+  if (!job) {
+    throw new WorkerApiError(404, 'job_not_found')
+  }
+  publishTranscriptionJobProgress(job, 'processing').catch((error) =>
+    console.error('Failed to publish transcription job start', error)
+  )
+  return job
+}
+
+export async function claimNextJob(workerClient: DocumentType<WorkerClient>) {
+  const readyJob = await claimReadyJob(workerClient)
+  if (readyJob) {
+    return readyJob
+  }
+
+  const now = new Date()
+  const legacyJob = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      status: TranscriptionJobStatus.queued,
+      sourceUrl: { $exists: true, $ne: '' },
+    },
+    {
+      $set: {
+        status: TranscriptionJobStatus.processing,
+        workerId: workerId(workerClient),
+        claimedAt: now,
+        heartbeatAt: now,
+      },
+      $inc: { attempts: 1 },
+    },
+    { sort: { createdAt: 1 }, new: true }
+  )
+
+  if (legacyJob) {
+    await WorkerClientModel.updateOne(
+      { _id: workerClient._id },
+      { $set: { lastClaimedAt: now } }
+    )
+    publishTranscriptionJobProgress(legacyJob, 'processing').catch((error) =>
+      console.error('Failed to publish transcription job start', error)
+    )
+  }
+
+  return legacyJob
+}
+
+export async function markJobDownloaded(
+  jobId: string,
+  workerClient: DocumentType<WorkerClient>,
+  body: Record<string, unknown>
+) {
+  assertObjectId(jobId)
+  const localSourcePath = validateOptionalString(
+    body.localSourcePath,
+    'invalid_local_source_path'
+  )
+  if (!localSourcePath?.trim()) {
+    throw new WorkerApiError(400, 'local_source_path_required')
+  }
+  const now = new Date()
+  const job = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      _id: jobId,
+      workerId: workerId(workerClient),
+      status: TranscriptionJobStatus.downloading,
+    },
+    {
+      $set: {
+        status: TranscriptionJobStatus.ready,
+        localSourcePath,
+        downloadedAt: now,
+        heartbeatAt: now,
+      },
+      $unset: { lastError: '' },
+    },
+    { new: true }
+  )
+  if (!job) {
+    throw new WorkerApiError(404, 'job_not_found')
+  }
   return job
 }
 
@@ -201,7 +339,14 @@ export async function getOwnedJob(
   const job = await TranscriptionJobModel.findOne({
     _id: jobId,
     workerId: workerId(workerClient),
-    status: TranscriptionJobStatus.processing,
+    status: {
+      $in: [
+        TranscriptionJobStatus.downloading,
+        TranscriptionJobStatus.ready,
+        TranscriptionJobStatus.transcribing,
+        TranscriptionJobStatus.processing,
+      ],
+    },
   })
   if (!job) {
     throw new WorkerApiError(404, 'job_not_found')
@@ -218,7 +363,14 @@ export async function heartbeatJob(
     {
       _id: jobId,
       workerId: workerId(workerClient),
-      status: TranscriptionJobStatus.processing,
+      status: {
+        $in: [
+          TranscriptionJobStatus.downloading,
+          TranscriptionJobStatus.ready,
+          TranscriptionJobStatus.transcribing,
+          TranscriptionJobStatus.processing,
+        ],
+      },
     },
     { $set: { heartbeatAt: new Date() } },
     { new: true }
@@ -252,7 +404,12 @@ export async function updateJobProgress(
     {
       _id: jobId,
       workerId: workerId(workerClient),
-      status: TranscriptionJobStatus.processing,
+      status: {
+        $in: [
+          TranscriptionJobStatus.transcribing,
+          TranscriptionJobStatus.processing,
+        ],
+      },
     },
     {
       $set: {
@@ -300,7 +457,12 @@ export async function completeJob(
     {
       _id: jobId,
       workerId: workerId(workerClient),
-      status: TranscriptionJobStatus.processing,
+      status: {
+        $in: [
+          TranscriptionJobStatus.transcribing,
+          TranscriptionJobStatus.processing,
+        ],
+      },
     },
     {
       $set: {
@@ -344,10 +506,16 @@ export async function failJob(
   const update = shouldRetry
     ? {
         $set: {
-          status: TranscriptionJobStatus.queued,
+          status: TranscriptionJobStatus.queuedForDownload,
           lastError: truncateError(body.error),
         },
-        $unset: { workerId: '', claimedAt: '', heartbeatAt: '' },
+        $unset: {
+          workerId: '',
+          claimedAt: '',
+          heartbeatAt: '',
+          localSourcePath: '',
+          downloadedAt: '',
+        },
       }
     : {
         $set: {
@@ -362,7 +530,14 @@ export async function failJob(
     {
       _id: jobId,
       workerId: workerId(workerClient),
-      status: TranscriptionJobStatus.processing,
+      status: {
+        $in: [
+          TranscriptionJobStatus.downloading,
+          TranscriptionJobStatus.ready,
+          TranscriptionJobStatus.transcribing,
+          TranscriptionJobStatus.processing,
+        ],
+      },
     },
     update,
     { new: true }

--- a/src/helpers/workerApi/router.ts
+++ b/src/helpers/workerApi/router.ts
@@ -1,12 +1,16 @@
 import * as express from 'express'
 import {
   WorkerApiError,
+  claimDownloadJob,
   claimNextJob,
+  claimReadyJob,
   completeJob,
   failJob,
   getOwnedJob,
   heartbeatJob,
+  markJobDownloaded,
   serializeJob,
+  startTranscriptionJob,
   updateJobProgress,
 } from '@/helpers/workerApi/jobService'
 import authenticateWorker, {
@@ -38,6 +42,30 @@ workerRouter.use(express.json({ limit: '1mb' }))
 workerRouter.use(authenticateWorker)
 
 workerRouter.post(
+  '/jobs/claim-download',
+  asyncRoute(async (request, response) => {
+    const job = await claimDownloadJob(workerClient(request))
+    if (!job) {
+      response.status(204).send()
+      return
+    }
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+workerRouter.post(
+  '/jobs/claim-ready',
+  asyncRoute(async (request, response) => {
+    const job = await claimReadyJob(workerClient(request))
+    if (!job) {
+      response.status(204).send()
+      return
+    }
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+workerRouter.post(
   '/jobs/claim',
   asyncRoute(async (request, response) => {
     const job = await claimNextJob(workerClient(request))
@@ -45,6 +73,29 @@ workerRouter.post(
       response.status(204).send()
       return
     }
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+workerRouter.post(
+  '/jobs/:id/downloaded',
+  asyncRoute(async (request, response) => {
+    const job = await markJobDownloaded(
+      request.params.id,
+      workerClient(request),
+      request.body || {}
+    )
+    response.json({ job: serializeJob(job) })
+  })
+)
+
+workerRouter.post(
+  '/jobs/:id/transcribe',
+  asyncRoute(async (request, response) => {
+    const job = await startTranscriptionJob(
+      request.params.id,
+      workerClient(request)
+    )
     response.json({ job: serializeJob(job) })
   })
 )
@@ -67,6 +118,7 @@ workerRouter.get(
         fileId: job.fileId,
         fileUniqueId: job.fileUniqueId,
         filePath: job.filePath,
+        localSourcePath: job.localSourcePath,
         fileSize: job.fileSize,
         mimeType: job.mimeType,
         fileName: job.fileName,

--- a/src/models/TranscriptionJob.ts
+++ b/src/models/TranscriptionJob.ts
@@ -8,6 +8,10 @@ import {
 } from '@typegoose/typegoose'
 
 export enum TranscriptionJobStatus {
+  queuedForDownload = 'queued_for_download',
+  downloading = 'downloading',
+  ready = 'ready',
+  transcribing = 'transcribing',
   queued = 'queued',
   processing = 'processing',
   completed = 'completed',
@@ -45,7 +49,7 @@ export class TranscriptionJob {
   @prop({
     required: true,
     enum: TranscriptionJobStatus,
-    default: TranscriptionJobStatus.queued,
+    default: TranscriptionJobStatus.queuedForDownload,
     index: true,
   })
   status: TranscriptionJobStatus
@@ -68,6 +72,8 @@ export class TranscriptionJob {
   @prop()
   filePath?: string
   @prop()
+  localSourcePath?: string
+  @prop()
   fileSize?: number
   @prop()
   mimeType?: string
@@ -75,8 +81,8 @@ export class TranscriptionJob {
   fileName?: string
   @prop({ required: true, enum: TranscriptionJobSourceKind })
   sourceKind: TranscriptionJobSourceKind
-  @prop({ required: true })
-  sourceUrl: string
+  @prop()
+  sourceUrl?: string
   @prop()
   requestedByUserId?: string
   @prop()
@@ -91,6 +97,8 @@ export class TranscriptionJob {
   workerId?: string
   @prop()
   claimedAt?: Date
+  @prop()
+  downloadedAt?: Date
   @prop()
   heartbeatAt?: Date
   @prop({ required: true, default: 0 })

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -22,6 +22,7 @@ interface WorkerJob {
   sourceUrl?: string
   sourceKind?: string
   mimeType?: string
+  localSourcePath?: string
   recognitionLanguageHint?: string
   attempts?: number
 }
@@ -31,12 +32,14 @@ interface ClaimResponse {
 }
 
 interface WorkerSource {
-  sourceUrl: string
+  sourceUrl?: string
   sourceKind?: string
   mimeType?: string
   fileName?: string
   fileId?: string
   fileUniqueId?: string
+  filePath?: string
+  localSourcePath?: string
 }
 
 interface SourceResponse {
@@ -64,6 +67,10 @@ interface WorkerConfig {
   pollIntervalMs: number
   heartbeatIntervalMs: number
   downloadTimeoutMs: number
+  downloadConcurrency: number
+  transcriptionConcurrency: number
+  telegramBotApiUrl: string
+  telegramBotToken?: string
   idleExit: boolean
   language?: string
   engine: string
@@ -79,6 +86,11 @@ interface Logger {
 interface RunCommandResult {
   stdout: string
   stderr: string
+}
+
+interface DownloadedJob {
+  job: WorkerJob
+  inputPath: string
 }
 
 const consoleLogger: Logger = {
@@ -149,6 +161,26 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): WorkerConfig {
       DEFAULT_DOWNLOAD_TIMEOUT_MS,
       'VOICY_WORKER_DOWNLOAD_TIMEOUT_MS'
     ),
+    downloadConcurrency: Math.max(
+      1,
+      numberFromEnv(
+        env.VOICY_WORKER_DOWNLOAD_CONCURRENCY,
+        2,
+        'VOICY_WORKER_DOWNLOAD_CONCURRENCY'
+      )
+    ),
+    transcriptionConcurrency: Math.max(
+      1,
+      numberFromEnv(
+        env.VOICY_WORKER_TRANSCRIPTION_CONCURRENCY,
+        1,
+        'VOICY_WORKER_TRANSCRIPTION_CONCURRENCY'
+      )
+    ),
+    telegramBotApiUrl: (
+      env.VOICY_WORKER_TELEGRAM_API_URL || 'https://api.telegram.org'
+    ).replace(/\/+$/, ''),
+    telegramBotToken: env.VOICY_WORKER_TELEGRAM_BOT_TOKEN || env.TOKEN,
     idleExit: booleanFromEnv(env.VOICY_WORKER_IDLE_EXIT),
     language: env.VOICY_WORKER_LANGUAGE,
     engine: env.VOICY_WORKER_ENGINE || 'faster-whisper',
@@ -175,9 +207,35 @@ async function claimJob(api: AxiosInstance) {
   return (response.data as ClaimResponse).job
 }
 
+async function claimDownloadJob(api: AxiosInstance) {
+  const response = await api.post('/jobs/claim-download', undefined, {
+    validateStatus: (status) => status === 200 || status === 204,
+  })
+  if (response.status === 204) {
+    return undefined
+  }
+  return (response.data as ClaimResponse).job
+}
+
 async function getSource(api: AxiosInstance, jobId: string) {
   const response = await api.get(`/jobs/${jobId}/source`)
   return (response.data as SourceResponse).source
+}
+
+async function markDownloaded(
+  api: AxiosInstance,
+  jobId: string,
+  inputPath: string
+) {
+  const response = await api.post(`/jobs/${jobId}/downloaded`, {
+    localSourcePath: inputPath,
+  })
+  return (response.data as ClaimResponse).job
+}
+
+async function startTranscription(api: AxiosInstance, jobId: string) {
+  const response = await api.post(`/jobs/${jobId}/transcribe`)
+  return (response.data as ClaimResponse).job
 }
 
 const extensionByMimeType: Record<string, string> = {
@@ -219,9 +277,16 @@ export function extensionForSource(source: WorkerSource) {
   if (source.sourceKind === 'video_note' || source.sourceKind === 'video') {
     return '.mp4'
   }
-  const urlPath = new URL(source.sourceUrl).pathname
-  const ext = path.extname(urlPath)
-  return ext || '.ogg'
+  if (source.sourceUrl) {
+    const urlPath = new URL(source.sourceUrl).pathname
+    const ext = path.extname(urlPath)
+    return ext || '.ogg'
+  }
+  if (source.filePath) {
+    const ext = path.extname(source.filePath)
+    return ext || '.ogg'
+  }
+  return '.ogg'
 }
 
 function isLoopbackHost(hostname: string) {
@@ -230,9 +295,16 @@ function isLoopbackHost(hostname: string) {
   )
 }
 
-function assertAllowedSourceUrl(sourceUrl: string, apiUrl: string) {
+function assertAllowedSourceUrl(sourceUrl: string, config: WorkerConfig) {
   const parsed = new URL(sourceUrl)
-  const api = new URL(apiUrl)
+  const api = new URL(config.apiUrl)
+  const telegramApi = new URL(config.telegramBotApiUrl)
+  if (
+    parsed.origin === telegramApi.origin &&
+    (parsed.protocol === 'https:' || isLoopbackHost(parsed.hostname))
+  ) {
+    return
+  }
   if (isLoopbackHost(parsed.hostname) && isLoopbackHost(api.hostname)) {
     return
   }
@@ -249,8 +321,54 @@ async function removeIfExists(filePath: string) {
   })
 }
 
+function telegramFileUrl(config: WorkerConfig, filePath: string) {
+  if (!config.telegramBotToken) {
+    throw new WorkerClientError(
+      'VOICY_WORKER_TELEGRAM_BOT_TOKEN or TOKEN is required to download Telegram media',
+      false
+    )
+  }
+  const encodedPath = filePath
+    .replace(/^\/+/, '')
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/')
+  return `${config.telegramBotApiUrl}/file/bot${config.telegramBotToken}/${encodedPath}`
+}
+
+async function resolveSourceUrl(config: WorkerConfig, source: WorkerSource) {
+  if (source.sourceUrl) {
+    return source.sourceUrl
+  }
+  if (source.filePath) {
+    return telegramFileUrl(config, source.filePath)
+  }
+  if (!source.fileId) {
+    throw new WorkerClientError('Job source has no URL or Telegram file id')
+  }
+  if (!config.telegramBotToken) {
+    throw new WorkerClientError(
+      'VOICY_WORKER_TELEGRAM_BOT_TOKEN or TOKEN is required to resolve Telegram file ids',
+      false
+    )
+  }
+  const response = await axios.get(
+    `${config.telegramBotApiUrl}/bot${config.telegramBotToken}/getFile`,
+    {
+      params: { file_id: source.fileId },
+      timeout: config.downloadTimeoutMs,
+    }
+  )
+  const filePath = response.data?.result?.file_path
+  if (typeof filePath !== 'string' || !filePath) {
+    throw new WorkerClientError(
+      'Telegram getFile response did not include file_path'
+    )
+  }
+  return telegramFileUrl(config, filePath)
+}
+
 async function downloadSource(
-  api: AxiosInstance,
   config: WorkerConfig,
   job: WorkerJob,
   source: WorkerSource
@@ -261,8 +379,9 @@ async function downloadSource(
     `${job.id}${extensionForSource(source)}`
   )
   await removeIfExists(inputPath)
-  assertAllowedSourceUrl(source.sourceUrl, config.apiUrl)
-  const response = await axios.get(source.sourceUrl, {
+  const sourceUrl = await resolveSourceUrl(config, source)
+  assertAllowedSourceUrl(sourceUrl, config)
+  const response = await axios.get(sourceUrl, {
     responseType: 'stream',
     timeout: config.downloadTimeoutMs,
   })
@@ -435,13 +554,17 @@ export async function processNextJob(
   config: WorkerConfig,
   logger: Logger = consoleLogger
 ) {
-  const api = createApi(config)
-  const job = await claimJob(api)
-  if (!job) {
-    return false
-  }
+  const processed = await processAvailableJobs(config, logger)
+  return processed > 0
+}
 
-  logger.info(`Claimed transcription job ${job.id}`)
+async function downloadJob(
+  api: AxiosInstance,
+  config: WorkerConfig,
+  job: WorkerJob,
+  logger: Logger
+): Promise<DownloadedJob | undefined> {
+  logger.info(`Claimed media download job ${job.id}`)
   const heartbeat = startHeartbeat(
     api,
     job.id,
@@ -451,19 +574,133 @@ export async function processNextJob(
 
   try {
     const source = await getSource(api, job.id)
-    const inputPath = await downloadSource(api, config, job, source)
-    const result = await transcribeJob(config, job, inputPath)
-    await api.post(`/jobs/${job.id}/result`, result)
-    logger.info(`Completed transcription job ${job.id}`)
-    return true
+    const inputPath = await downloadSource(config, job, source)
+    const readyJob = await markDownloaded(api, job.id, inputPath)
+    logger.info(`Downloaded media for job ${job.id}`)
+    return { job: readyJob, inputPath }
   } catch (error) {
     await failJob(api, job.id, error, logger)
-    return true
+    return undefined
   } finally {
     if (heartbeat) {
       clearInterval(heartbeat)
     }
   }
+}
+
+async function transcribeDownloadedJob(
+  api: AxiosInstance,
+  config: WorkerConfig,
+  downloaded: DownloadedJob,
+  logger: Logger
+) {
+  const job = ['processing', 'transcribing'].includes(downloaded.job.status)
+    ? downloaded.job
+    : await startTranscription(api, downloaded.job.id)
+  logger.info(`Started transcription job ${job.id}`)
+  const heartbeat = startHeartbeat(
+    api,
+    job.id,
+    config.heartbeatIntervalMs,
+    logger
+  )
+
+  try {
+    const result = await transcribeJob(config, job, downloaded.inputPath)
+    await api.post(`/jobs/${job.id}/result`, result)
+    logger.info(`Completed transcription job ${job.id}`)
+  } catch (error) {
+    await failJob(api, job.id, error, logger)
+  } finally {
+    if (heartbeat) {
+      clearInterval(heartbeat)
+    }
+  }
+}
+
+export async function processAvailableJobs(
+  config: WorkerConfig,
+  logger: Logger = consoleLogger
+) {
+  const api = createApi(config)
+  const readyQueue: DownloadedJob[] = []
+  const downloads = new Set<Promise<void>>()
+  const transcriptions = new Set<Promise<void>>()
+  let downloadQueueExhausted = false
+  let processed = 0
+
+  const startDownload = async (job: WorkerJob) => {
+    const ready = await downloadJob(api, config, job, logger)
+    if (ready) {
+      readyQueue.push(ready)
+    }
+  }
+
+  const fillDownloads = async () => {
+    while (
+      !downloadQueueExhausted &&
+      downloads.size < config.downloadConcurrency
+    ) {
+      const job = await claimDownloadJob(api)
+      if (!job) {
+        downloadQueueExhausted = true
+        return
+      }
+      processed += 1
+      const task = startDownload(job).finally(() => downloads.delete(task))
+      downloads.add(task)
+    }
+  }
+
+  const fillTranscriptions = () => {
+    while (
+      readyQueue.length > 0 &&
+      transcriptions.size < config.transcriptionConcurrency
+    ) {
+      const ready = readyQueue.shift()
+      if (!ready) {
+        return
+      }
+      const task = transcribeDownloadedJob(api, config, ready, logger).finally(
+        () => transcriptions.delete(task)
+      )
+      transcriptions.add(task)
+    }
+  }
+
+  let cycleComplete = false
+  while (!cycleComplete) {
+    await fillDownloads()
+    fillTranscriptions()
+
+    if (
+      downloads.size === 0 &&
+      transcriptions.size === 0 &&
+      readyQueue.length === 0
+    ) {
+      cycleComplete = true
+      continue
+    }
+
+    await Promise.race([...downloads, ...transcriptions])
+  }
+
+  const legacyJob = processed === 0 ? await claimJob(api) : undefined
+  if (!legacyJob) {
+    return processed
+  }
+
+  const source = await getSource(api, legacyJob.id)
+  const inputPath =
+    legacyJob.localSourcePath ||
+    (await downloadSource(config, legacyJob, source))
+  await transcribeDownloadedJob(
+    api,
+    config,
+    { job: legacyJob, inputPath },
+    logger
+  )
+  return processed + 1
 }
 
 function delay(ms: number) {
@@ -483,14 +720,14 @@ export async function runWorker(
   process.once('SIGTERM', stop)
 
   while (!stopped) {
-    const processed = await processNextJob(config, logger)
-    if (!processed && config.idleExit) {
+    const processed = await processAvailableJobs(config, logger)
+    if (processed === 0 && config.idleExit) {
       logger.info(
         'No queued jobs; exiting because VOICY_WORKER_IDLE_EXIT is set'
       )
       break
     }
-    if (!processed) {
+    if (processed === 0) {
       await delay(config.pollIntervalMs)
     }
   }


### PR DESCRIPTION
## Summary
- enqueue Telegram media jobs with file metadata instead of persisted bot-token file URLs
- add worker API states/endpoints for download acquisition, ready local files, and transcription start
- update the Windows worker to resolve/download Telegram media locally via configurable Bot API endpoint, run parallel downloads, and transcribe ready files by completion order
- document local Bot API, download/transcription concurrency, configurable media size limits, and compatibility with current model/progress/media coverage docs on `main`

## Testing
- `yarn build-ts`
- `yarn lint`
- `yarn test:worker-client`
- `MONGO=mongodb://127.0.0.1:27018/voicy_worker_proof yarn test:worker-api`
- `MONGO=mongodb://127.0.0.1:27018/voicy_worker_e2e_proof yarn test:worker-e2e`
- `yarn test:progress-policy`
- `yarn test:media-coverage`
- `git diff --check origin/main...HEAD`

## Review guidance
Automated proof covers local Telegram Bot API `getFile`/file download resolution and a scheduling case where `small-job` transcribes before an earlier `slow-job` finishes downloading. Rework rebased PR #140 onto current `main` after #139, preserving media classification and filename/MIME extension handling while adding worker-local download scheduling.
