### PR TITLE
Fix language picker callback polling

### DIFF
--- a/scripts/language-selection-proof.js
+++ b/scripts/language-selection-proof.js
@@ -9,6 +9,7 @@ function createContext({
   telegramLanguage = 'en',
   uiLanguage = 'en',
   manual = false,
+  editMessageText,
 } = {}) {
   const calls = []
   const dbchat = {
@@ -39,8 +40,9 @@ function createContext({
       callbackQuery: { data: 'li~1~ru' },
       dbchat,
       i18n,
-      editMessageText: async (text, options) =>
-        calls.push(['edit', text, options]),
+      editMessageText:
+        editMessageText ||
+        (async (text, options) => calls.push(['edit', text, options])),
       answerCallbackQuery: async () => calls.push(['answerCallbackQuery']),
       reply: async (text, options) => calls.push(['reply', text, options]),
       msg: { message_id: 1 },
@@ -87,9 +89,38 @@ async function provesTelegramLanguageStillInitializesUnselectedChats() {
   assert.deepEqual(calls[1], ['reply', 'ru:start:', { parse_mode: 'Markdown' }])
 }
 
+async function provesLanguageCallbackFallsBackWhenEditFails() {
+  const { ctx, calls } = createContext({
+    editMessageText: async () => {
+      calls.push(['editFailed'])
+      throw new Error('message is not modified')
+    },
+  })
+
+  const originalLog = console.log
+  console.log = () => undefined
+  try {
+    await handleSetLanguage(ctx)
+  } finally {
+    console.log = originalLog
+  }
+
+  assert.equal(ctx.dbchat.uiLanguage, 'ru')
+  assert.equal(ctx.dbchat.uiLanguageSelectedManually, true)
+  assert.deepEqual(calls[0], ['answerCallbackQuery'])
+  assert.deepEqual(calls[1], ['save', 'ru', true])
+  assert.deepEqual(calls[2], ['editFailed'])
+  assert.deepEqual(calls[3], [
+    'reply',
+    'ru:language_success:Русский',
+    { parse_mode: 'Markdown' },
+  ])
+}
+
 Promise.resolve()
   .then(provesManualLanguageSurvivesStart)
   .then(provesTelegramLanguageStillInitializesUnselectedChats)
+  .then(provesLanguageCallbackFallsBackWhenEditFails)
   .then(() => {
     console.log('language selection proof passed')
   })

--- a/scripts/language-selection-proof.js
+++ b/scripts/language-selection-proof.js
@@ -4,6 +4,8 @@ const assert = require('assert')
 
 const handleSetLanguage = require('../dist/handlers/handleSetLanguage').default
 const handleStart = require('../dist/commands/handleStart').default
+const telegramAllowedUpdates =
+  require('../dist/helpers/telegramAllowedUpdates').default
 
 function createContext({
   telegramLanguage = 'en',
@@ -117,7 +119,12 @@ async function provesLanguageCallbackFallsBackWhenEditFails() {
   ])
 }
 
+function provesRuntimePollsForCallbackQueries() {
+  assert(telegramAllowedUpdates.includes('callback_query'))
+}
+
 Promise.resolve()
+  .then(provesRuntimePollsForCallbackQueries)
   .then(provesManualLanguageSurvivesStart)
   .then(provesTelegramLanguageStillInitializesUnselectedChats)
   .then(provesLanguageCallbackFallsBackWhenEditFails)

--- a/scripts/telegram-runtime-check.js
+++ b/scripts/telegram-runtime-check.js
@@ -49,6 +49,17 @@ async function main() {
   }
 
   const webhookInfo = webhook.body.result
+  if (
+    Array.isArray(webhookInfo.allowed_updates) &&
+    !webhookInfo.allowed_updates.includes('callback_query')
+  ) {
+    fail('Telegram runtime is not subscribed to callback_query updates', {
+      bot: `@${username}`,
+      allowed_updates: webhookInfo.allowed_updates,
+      pending_update_count: webhookInfo.pending_update_count,
+    })
+  }
+
   if (webhookInfo.url) {
     console.log(
       JSON.stringify(

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,7 @@ import i18n from '@/helpers/i18n'
 import ignoreOldMessageUpdates from '@/middlewares/ignoreOldMessageUpdates'
 import recordTimeReceived from '@/middlewares/recordTimeReceived'
 import startMongo from '@/helpers/startMongo'
+import telegramAllowedUpdates from '@/helpers/telegramAllowedUpdates'
 
 async function runApp() {
   console.log('Starting app...')
@@ -76,7 +77,7 @@ async function runApp() {
   // Start bot
   await bot.init()
   await configureBotCommands()
-  run(bot)
+  run(bot, 500, { allowed_updates: telegramAllowedUpdates })
   console.info(`Bot ${bot.botInfo.username} is up and running`)
   // Start webhook app
   webhookApp.listen(4242, () => console.log('Running on port 4242'))

--- a/src/handlers/handleSetLanguage.ts
+++ b/src/handlers/handleSetLanguage.ts
@@ -43,14 +43,20 @@ export default async function handleSetLanguage(ctx: Context) {
   await ctx.dbchat.save()
   ctx.i18n.locale(languageObject.code)
 
-  await ctx.editMessageText(
-    markdownI18n(ctx, 'language_success', {
-      language: languageObject.name,
-    }),
-    {
+  const successMessage = markdownI18n(ctx, 'language_success', {
+    language: languageObject.name,
+  })
+
+  try {
+    await ctx.editMessageText(successMessage, {
       parse_mode: 'Markdown',
-    }
-  )
+    })
+  } catch (error) {
+    report(error, { ctx, location: 'handleSetLanguage.successEdit' })
+    await ctx.reply(successMessage, {
+      parse_mode: 'Markdown',
+    })
+  }
 
   if (!isCommand) {
     await sendStart(ctx)

--- a/src/helpers/telegramAllowedUpdates.ts
+++ b/src/helpers/telegramAllowedUpdates.ts
@@ -1,0 +1,8 @@
+const telegramAllowedUpdates = [
+  'message',
+  'edited_message',
+  'callback_query',
+  'my_chat_member',
+] as const
+
+export default telegramAllowedUpdates


### PR DESCRIPTION
## Summary
- Add an explicit Telegram `allowed_updates` list for long polling so inline keyboard `callback_query` updates are delivered even when Telegram had a stale message-only subscription.
- Keep the failed `editMessageText` fallback from the first patch so users still get a visible confirmation if Telegram rejects the edit.
- Extend regression coverage for callback polling and make the Telegram runtime check fail when `callback_query` is missing from the live subscription.

## Validation
- `yarn build-ts`
- `yarn test:language-selection`
- `yarn lint`
- `TELEGRAM_TEST_BOT_USERNAME=okamikron_bot yarn test:telegram-runtime`
- `git diff --check`

## Live Telegram QA Evidence
Branch runtime served `@okamikron_bot` from this workspace with `MONGO=mongodb://127.0.0.1:27018/voicy_telegram_qa` after stopping the stale `voicy-current-bot` launchd job.

- Runtime subscription evidence: `getWebhookInfo` reported `allowed_updates: ["message", "edited_message", "callback_query", "my_chat_member"]`.
- CDP helper sent `/language` to `@okamikron_bot` at `http://127.0.0.1:9222` and verified the sent command.
- CDP mouse click on the inline `Русский` button reached the handler; branch runtime logged `setting language answered in 0.685s`.
- Telegram Web showed: `👍 Теперь Войси использует Русский для сообщений бота в этом чате.`
- CDP helper sent `/start` and verified Russian start copy: `Здравствуйте. Войси превращает голосовые сообщения`.
- CDP helper sent `/help` and verified Russian help copy: `Войси превращает голосовые сообщения и аудиофайлы`.
- CDP helper sent `/donate` and verified Russian donate-state copy: `Расшифровка голосовых уже включена`.

## Testing / Review Guidance
The prior failure reproduced with this branch owning polling before the fix: `/language` rendered the picker, but pressing `Русский` did not hit `handleSetLanguage`; Telegram was subscribed only to `message` and `edited_message`. The updated branch fixes that by forcing callback polling at startup. Manual review can repeat the same path in Telegram Web: send `/language`, press `Русский`, then run `/start`, `/help`, and `/donate` and confirm Russian copy remains active.