### PR TITLE
Replace worker shell transcribe command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ $env:VOICY_WORKER_TELEGRAM_BOT_TOKEN = "<telegram-bot-token>"
 $env:VOICY_WORKER_TELEGRAM_API_URL = "http://127.0.0.1:8081"
 $env:VOICY_WORKER_DOWNLOAD_CONCURRENCY = "2"
 $env:VOICY_WORKER_TRANSCRIPTION_CONCURRENCY = "1"
-$env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language} {model}"
+$env:VOICY_WORKER_TRANSCRIBE_EXECUTABLE = "C:\voicy-worker\.venv\Scripts\python.exe"
+$env:VOICY_WORKER_TRANSCRIBE_ARGS_JSON = '["C:\\voicy-worker\\transcribe.py","{input}","{output}","{language}","{model}"]'
 yarn worker:run
 ```
 
@@ -96,7 +97,8 @@ export the worker API/token environment, then inspect the generated plist:
 yarn build-ts
 export VOICY_WORKER_API_URL=http://127.0.0.1:3000/worker/v1
 export VOICY_WORKER_TOKEN=voicy_worker_...
-export VOICY_WORKER_TRANSCRIBE_COMMAND='node scripts/whisper-transcriber.js {input} {output} {language}'
+export VOICY_WORKER_TRANSCRIBE_EXECUTABLE="$(command -v node)"
+export VOICY_WORKER_TRANSCRIBE_ARGS_JSON='["scripts/whisper-transcriber.js","{input}","{output}","{language}"]'
 yarn worker:print-macos-test-launchd
 ```
 

--- a/docs/security-audit-2026-05-01.md
+++ b/docs/security-audit-2026-05-01.md
@@ -150,11 +150,11 @@ Recommendation:
 
 ### MEDIUM-01: Worker command execution still uses a shell template
 
-Status: follow-up required.
+Status: remediated in VOI-KANEO-28.
 
-`src/workerClient/runWindowsWorker.ts` builds a command string from
-`VOICY_WORKER_TRANSCRIBE_COMMAND` and runs it with `spawn(command, { shell:
-true })`. Inputs are quoted with `JSON.stringify`, which is not a complete
+The vulnerable implementation built a command string from
+`VOICY_WORKER_TRANSCRIBE_COMMAND` and ran it with `spawn(command, { shell:
+true })`. Inputs were quoted with `JSON.stringify`, which is not a complete
 shell-escaping strategy on POSIX shells and is brittle across Windows shells.
 
 Impact:
@@ -162,11 +162,12 @@ Impact:
   command injection becomes possible.
 - Operator-provided command templates are harder to validate and test safely.
 
-Recommendation:
-- Replace the shell-template contract with an executable plus argument array, or
-  a small fixed set of supported engines.
-- If shell execution must remain, implement explicit per-platform escaping and
-  tests for paths containing quotes, spaces, `$`, backticks, and parentheses.
+Remediation:
+- The worker now requires `VOICY_WORKER_TRANSCRIBE_EXECUTABLE` plus
+  `VOICY_WORKER_TRANSCRIBE_ARGS_JSON` and calls `spawn(executable, args, {
+  shell: false })`.
+- Worker proof coverage includes paths containing quotes, spaces, `$`,
+  backticks, and parentheses.
 
 ### MEDIUM-02: Error reporting logs the full Grammy context
 

--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -66,8 +66,8 @@ python -m pip install faster-whisper
 becomes a problem.
 
 Use `VOICY_WORKER_MODEL` as the worker-level model selector. The worker passes
-that value to the transcription command as the `{model}` template token, exports
-it to child processes as `VOICY_WORKER_MODEL`, and records it in result
+that value to transcription argv entries through the `{model}` placeholder,
+exports it to child processes as `VOICY_WORKER_MODEL`, and records it in result
 metadata. If unset, the worker defaults to `large-v3`, which is the recommended
 quality-first model for the RTX 4070 Ti host. Use smaller models only when the
 machine cannot meet memory or latency needs.
@@ -146,7 +146,8 @@ $env:VOICY_WORKER_TELEGRAM_BOT_TOKEN = "<telegram-bot-token>"
 $env:VOICY_WORKER_TELEGRAM_API_URL = "http://127.0.0.1:8081"
 $env:VOICY_WORKER_DOWNLOAD_CONCURRENCY = "2"
 $env:VOICY_WORKER_TRANSCRIPTION_CONCURRENCY = "1"
-$env:VOICY_WORKER_TRANSCRIBE_COMMAND = "C:\voicy-worker\.venv\Scripts\python.exe C:\voicy-worker\transcribe.py {input} {output} {language} {model}"
+$env:VOICY_WORKER_TRANSCRIBE_EXECUTABLE = "C:\voicy-worker\.venv\Scripts\python.exe"
+$env:VOICY_WORKER_TRANSCRIBE_ARGS_JSON = '["C:\\voicy-worker\\transcribe.py","{input}","{output}","{language}","{model}"]'
 ```
 
 `VOICY_WORKER_TELEGRAM_API_URL` may point at a worker-local Telegram Bot API
@@ -161,7 +162,8 @@ $env:VOICY_WHISPER_MODEL = "small"
 $env:VOICY_WHISPER_COMMAND = "C:\Users\<user>\AppData\Local\Programs\Python\Python311\Scripts\whisper.exe"
 $env:VOICY_WORKER_ENGINE = "openai-whisper-cli"
 $env:VOICY_WORKER_MODEL = "small"
-$env:VOICY_WORKER_TRANSCRIBE_COMMAND = "node scripts/whisper-transcriber.js {input} {output} {language}"
+$env:VOICY_WORKER_TRANSCRIBE_EXECUTABLE = "node"
+$env:VOICY_WORKER_TRANSCRIBE_ARGS_JSON = '["scripts/whisper-transcriber.js","{input}","{output}","{language}"]'
 ```
 
 `VOICY_WHISPER_COMMAND` is optional when `whisper` is already on `PATH`, but it
@@ -206,7 +208,8 @@ For each claimed job it:
 3. Downloads the media into `VOICY_WORKER_WORK_DIR`.
 4. Marks the job `ready` with `POST /jobs/:id/downloaded`.
 5. Starts transcription with `POST /jobs/:id/transcribe`.
-6. Runs `VOICY_WORKER_TRANSCRIBE_COMMAND`.
+6. Runs `VOICY_WORKER_TRANSCRIBE_EXECUTABLE` with
+   `VOICY_WORKER_TRANSCRIBE_ARGS_JSON`.
 7. Reads transcript JSON from `{output}` or plain text from stdout.
 8. Uploads the result to `POST /jobs/:id/result`.
 
@@ -215,10 +218,13 @@ transcription scheduler consumes whichever download becomes ready first, so a
 large slow file does not block a later smaller file that has already reached
 local disk.
 
-The command template supports `{input}`, `{output}`, `{language}`, and
-`{model}`. Paths and values are quoted before replacement so spaces in Windows
-paths are supported. `scripts/whisper-transcriber.js` reads
-`VOICY_WORKER_MODEL` directly, so it does not need `{model}` in the command.
+`VOICY_WORKER_TRANSCRIBE_ARGS_JSON` must be a JSON array of argument strings.
+Each argument may contain `{input}`, `{output}`, `{language}`, and `{model}`.
+The worker replaces those placeholders and then starts the executable with an
+argv array, without a shell. That preserves spaces, quotes, dollar signs,
+backticks, and parentheses in paths and prevents shell expansion.
+`scripts/whisper-transcriber.js` reads `VOICY_WORKER_MODEL` directly, so it does
+not need `{model}` in the args array.
 
 The checked-in worker client uploads the final result after the command exits.
 Streaming-capable custom workers may call `POST /jobs/:id/progress` while a
@@ -275,7 +281,8 @@ Build the repo, export the worker environment, and print the generated plist:
 yarn build-ts
 export VOICY_WORKER_API_URL=http://127.0.0.1:3000/worker/v1
 export VOICY_WORKER_TOKEN=voicy_worker_...
-export VOICY_WORKER_TRANSCRIBE_COMMAND='node scripts/whisper-transcriber.js {input} {output} {language}'
+export VOICY_WORKER_TRANSCRIBE_EXECUTABLE="$(command -v node)"
+export VOICY_WORKER_TRANSCRIBE_ARGS_JSON='["scripts/whisper-transcriber.js","{input}","{output}","{language}"]'
 yarn worker:print-macos-test-launchd
 ```
 

--- a/scripts/fake-transcriber.js
+++ b/scripts/fake-transcriber.js
@@ -26,6 +26,6 @@ fs.writeFileSync(
     ],
     language: 'en',
     duration: 1.5,
-    metadata: { model },
+    metadata: { model, inputPath, outputPath, argv: process.argv.slice(2) },
   })
 )

--- a/scripts/install-macos-test-worker-launchd.js
+++ b/scripts/install-macos-test-worker-launchd.js
@@ -117,9 +117,16 @@ function plist() {
       process.env.VOICY_WORKER_MODEL ||
       process.env.VOICY_WHISPER_MODEL ||
       'turbo',
-    VOICY_WORKER_TRANSCRIBE_COMMAND:
-      process.env.VOICY_WORKER_TRANSCRIBE_COMMAND ||
-      'node scripts/whisper-transcriber.js {input} {output} {language}',
+    VOICY_WORKER_TRANSCRIBE_EXECUTABLE:
+      process.env.VOICY_WORKER_TRANSCRIBE_EXECUTABLE || process.execPath,
+    VOICY_WORKER_TRANSCRIBE_ARGS_JSON:
+      process.env.VOICY_WORKER_TRANSCRIBE_ARGS_JSON ||
+      JSON.stringify([
+        'scripts/whisper-transcriber.js',
+        '{input}',
+        '{output}',
+        '{language}',
+      ]),
     VOICY_WHISPER_MODEL:
       process.env.VOICY_WHISPER_MODEL ||
       process.env.VOICY_WORKER_MODEL ||

--- a/scripts/local-whisper-worker-proof.js
+++ b/scripts/local-whisper-worker-proof.js
@@ -279,8 +279,13 @@ async function main() {
         server.address().port
       }/worker/v1`,
       VOICY_WORKER_TOKEN: 'local-whisper-proof-token',
-      VOICY_WORKER_TRANSCRIBE_COMMAND:
-        'node scripts/whisper-transcriber.js {input} {output} {language}',
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        'scripts/whisper-transcriber.js',
+        '{input}',
+        '{output}',
+        '{language}',
+      ]),
       VOICY_WORKER_WORK_DIR: workerDir,
       VOICY_WORKER_ENGINE: 'openai-whisper-cli',
       VOICY_WORKER_MODEL: process.env.VOICY_WORKER_MODEL || 'tiny',

--- a/scripts/qa-vnext-proof.js
+++ b/scripts/qa-vnext-proof.js
@@ -160,8 +160,13 @@ async function main() {
         apiServer.address().port
       }/worker/v1`,
       VOICY_WORKER_TOKEN: token,
-      VOICY_WORKER_TRANSCRIBE_COMMAND:
-        'node scripts/fake-transcriber.js {input} {output} {model}',
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        'scripts/fake-transcriber.js',
+        '{input}',
+        '{output}',
+        '{model}',
+      ]),
       VOICY_WORKER_WORK_DIR: path.join(
         os.tmpdir(),
         `voicy-vnext-qa-${process.pid}`

--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -412,15 +412,21 @@ async function main() {
 
   try {
     const baseUrl = `http://127.0.0.1:${server.address().port}/worker/v1`
+    const shellSensitiveWorkDir = path.join(
+      os.tmpdir(),
+      `voicy worker proof ' "$\`$(x)-${process.pid}`
+    )
     const env = {
       VOICY_WORKER_API_URL: baseUrl,
       VOICY_WORKER_TOKEN: 'proof-worker-token',
-      VOICY_WORKER_TRANSCRIBE_COMMAND:
-        'node scripts/fake-transcriber.js {input} {output} {model}',
-      VOICY_WORKER_WORK_DIR: path.join(
-        os.tmpdir(),
-        `voicy-worker-proof-${process.pid}`
-      ),
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        'scripts/fake-transcriber.js',
+        '{input}',
+        '{output}',
+        '{model}',
+      ]),
+      VOICY_WORKER_WORK_DIR: shellSensitiveWorkDir,
       VOICY_WORKER_IDLE_EXIT: '1',
       VOICY_WORKER_ENGINE: 'proof-engine',
       VOICY_WORKER_MODEL: 'proof-model',
@@ -437,7 +443,10 @@ async function main() {
     })
 
     assert(processed, 'worker should process the claimed job')
-    assert(!state.failure, 'worker should not report failure')
+    assert(
+      !state.failure,
+      `worker should not report failure: ${JSON.stringify(state.failure)}`
+    )
     assert(state.downloaded, 'worker should mark media downloaded before STT')
     assert(
       state.transcribing,
@@ -456,6 +465,19 @@ async function main() {
     assert(
       state.result.metadata.model === 'proof-model',
       'worker should submit model metadata'
+    )
+    assert(
+      state.result.metadata.inputPath.includes(shellSensitiveWorkDir),
+      'worker should pass shell-sensitive input paths as a single argv value'
+    )
+    assert(
+      state.result.metadata.outputPath.includes(shellSensitiveWorkDir),
+      'worker should pass shell-sensitive output paths as a single argv value'
+    )
+    assert(
+      state.result.metadata.argv[0].includes(shellSensitiveWorkDir) &&
+        state.result.metadata.argv[1].includes(shellSensitiveWorkDir),
+      'worker transcriber argv should preserve spaces, quotes, dollar signs, backticks, and parentheses'
     )
     assert(
       !state.audioAuthorization,
@@ -482,8 +504,11 @@ async function main() {
     const config = loadConfig({
       VOICY_WORKER_API_URL: baseUrl,
       VOICY_WORKER_TOKEN: 'proof-worker-token',
-      VOICY_WORKER_TRANSCRIBE_COMMAND:
-        'node -e "process.stderr.write(\\"boom\\"); process.exit(3)"',
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        '-e',
+        'process.stderr.write("boom"); process.exit(3)',
+      ]),
       VOICY_WORKER_WORK_DIR: path.join(
         os.tmpdir(),
         `voicy-worker-failure-proof-${process.pid}`
@@ -525,8 +550,12 @@ async function main() {
       loadConfig({
         VOICY_WORKER_API_URL: baseUrl,
         VOICY_WORKER_TOKEN: 'proof-worker-token',
-        VOICY_WORKER_TRANSCRIBE_COMMAND:
-          'node scripts/fake-transcriber.js {input} {output}',
+        VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+        VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+          'scripts/fake-transcriber.js',
+          '{input}',
+          '{output}',
+        ]),
         VOICY_WORKER_WORK_DIR: path.join(
           os.tmpdir(),
           `voicy-worker-scheduling-proof-${process.pid}`

--- a/scripts/worker-e2e-proof.js
+++ b/scripts/worker-e2e-proof.js
@@ -100,8 +100,13 @@ async function main() {
         apiServer.address().port
       }/worker/v1`,
       VOICY_WORKER_TOKEN: token,
-      VOICY_WORKER_TRANSCRIBE_COMMAND:
-        'node scripts/fake-transcriber.js {input} {output} {model}',
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        'scripts/fake-transcriber.js',
+        '{input}',
+        '{output}',
+        '{model}',
+      ]),
       VOICY_WORKER_WORK_DIR: path.join(
         os.tmpdir(),
         `voicy-worker-e2e-${process.pid}`

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -62,7 +62,8 @@ interface TranscriptionOutput {
 interface WorkerConfig {
   apiUrl: string
   token: string
-  transcribeCommand: string
+  transcribeExecutable: string
+  transcribeArgs: string[]
   workDir: string
   pollIntervalMs: number
   heartbeatIntervalMs: number
@@ -134,16 +135,55 @@ function booleanFromEnv(value: string | undefined) {
   return value === '1' || value === 'true'
 }
 
+function stringArrayFromJsonEnv(
+  value: string | undefined,
+  name: string
+): string[] {
+  if (!value) {
+    throw new Error(`${name} is required`)
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`${name} must be a JSON array of strings: ${message}`)
+  }
+
+  if (
+    !Array.isArray(parsed) ||
+    parsed.some((item) => typeof item !== 'string')
+  ) {
+    throw new Error(`${name} must be a JSON array of strings`)
+  }
+
+  return parsed
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): WorkerConfig {
+  if (
+    env.VOICY_WORKER_TRANSCRIBE_COMMAND &&
+    !env.VOICY_WORKER_TRANSCRIBE_EXECUTABLE
+  ) {
+    throw new Error(
+      'VOICY_WORKER_TRANSCRIBE_COMMAND shell templates are no longer supported; set VOICY_WORKER_TRANSCRIBE_EXECUTABLE and VOICY_WORKER_TRANSCRIBE_ARGS_JSON'
+    )
+  }
+
   return {
     apiUrl: required(env.VOICY_WORKER_API_URL, 'VOICY_WORKER_API_URL').replace(
       /\/+$/,
       ''
     ),
     token: required(env.VOICY_WORKER_TOKEN, 'VOICY_WORKER_TOKEN'),
-    transcribeCommand: required(
-      env.VOICY_WORKER_TRANSCRIBE_COMMAND,
-      'VOICY_WORKER_TRANSCRIBE_COMMAND'
+    transcribeExecutable: required(
+      env.VOICY_WORKER_TRANSCRIBE_EXECUTABLE,
+      'VOICY_WORKER_TRANSCRIBE_EXECUTABLE'
+    ),
+    transcribeArgs: stringArrayFromJsonEnv(
+      env.VOICY_WORKER_TRANSCRIBE_ARGS_JSON,
+      'VOICY_WORKER_TRANSCRIBE_ARGS_JSON'
     ),
     workDir: env.VOICY_WORKER_WORK_DIR || DEFAULT_WORK_DIR,
     pollIntervalMs: numberFromEnv(
@@ -389,21 +429,19 @@ async function downloadSource(
   return inputPath
 }
 
-function quoteShellValue(value: string) {
-  return JSON.stringify(value)
-}
-
-function commandForJob(
+function commandArgsForJob(
   config: WorkerConfig,
   inputPath: string,
   outputPath: string,
   language?: string
 ) {
-  return config.transcribeCommand
-    .replace(/\{input\}/g, quoteShellValue(inputPath))
-    .replace(/\{output\}/g, quoteShellValue(outputPath))
-    .replace(/\{language\}/g, quoteShellValue(language || ''))
-    .replace(/\{model\}/g, quoteShellValue(config.model))
+  return config.transcribeArgs.map((arg) =>
+    arg
+      .replace(/\{input\}/g, () => inputPath)
+      .replace(/\{output\}/g, () => outputPath)
+      .replace(/\{language\}/g, () => language || '')
+      .replace(/\{model\}/g, () => config.model)
+  )
 }
 
 function commandEnv(config: WorkerConfig) {
@@ -415,12 +453,13 @@ function commandEnv(config: WorkerConfig) {
 }
 
 function runCommand(
-  command: string,
+  executable: string,
+  args: string[],
   config: WorkerConfig
 ): Promise<RunCommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, {
-      shell: true,
+    const child = spawn(executable, args, {
+      shell: false,
       windowsHide: true,
       env: commandEnv(config),
     })
@@ -429,7 +468,18 @@ function runCommand(
 
     child.stdout.on('data', (chunk) => stdoutChunks.push(Buffer.from(chunk)))
     child.stderr.on('data', (chunk) => stderrChunks.push(Buffer.from(chunk)))
-    child.on('error', reject)
+    child.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') {
+        reject(
+          new WorkerClientError(
+            `Unable to start transcription executable "${executable}". Set VOICY_WORKER_TRANSCRIBE_EXECUTABLE to an absolute executable path or include it in PATH.`,
+            false
+          )
+        )
+        return
+      }
+      reject(error)
+    })
     child.on('close', (code) => {
       const stdout = Buffer.concat(stdoutChunks).toString('utf8')
       const stderr = Buffer.concat(stderrChunks).toString('utf8')
@@ -510,8 +560,12 @@ async function transcribeJob(
   const outputPath = path.join(config.workDir, `${job.id}.transcript.json`)
   await removeIfExists(outputPath)
   const language = job.recognitionLanguageHint || config.language
-  const command = commandForJob(config, inputPath, outputPath, language)
-  const commandResult = await runCommand(command, config)
+  const args = commandArgsForJob(config, inputPath, outputPath, language)
+  const commandResult = await runCommand(
+    config.transcribeExecutable,
+    args,
+    config
+  )
   return readTranscriptionOutput(
     commandResult,
     outputPath,


### PR DESCRIPTION
## Summary
- replace the worker shell command template with VOICY_WORKER_TRANSCRIBE_EXECUTABLE plus VOICY_WORKER_TRANSCRIBE_ARGS_JSON
- spawn transcription with an argv array and shell disabled
- update worker proofs, launchd helper, and docs for the new config

## Validation
- yarn build-ts
- yarn lint
- yarn test:worker-client

Manual QA: not required; the changed surface is worker command construction, and the mock worker proof now runs through argv with a work directory containing spaces, quotes, dollar signs, backticks, and parentheses.