### PR TITLE
Sanitize Voicy runtime error logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:language-selection": "node scripts/language-selection-proof.js",
     "test:progress-policy": "node scripts/progress-policy-proof.js",
     "test:media-coverage": "node scripts/media-coverage-proof.js",
+    "test:report-sanitizer": "node scripts/report-sanitizer-proof.js",
     "test:telegram-runtime": "node scripts/telegram-runtime-check.js",
     "test:local-runtime-health": "node scripts/local-runtime-health.js",
     "qa:telegram-upload": "node scripts/telegram-web-upload-qa.mjs",

--- a/scripts/report-sanitizer-proof.js
+++ b/scripts/report-sanitizer-proof.js
@@ -1,0 +1,58 @@
+const assert = require('assert')
+const { sanitizeErrorReport } = require('../dist/helpers/report')
+
+const secretTelegramToken = [
+  '123456789',
+  'abcdefghijklmnopqrstuvwxyzABCDE',
+].join(':')
+const secretStripeKey = ['sk', 'live', 'abcdefghijklmnopqrstuvwxyz'].join('_')
+const secretMongoUrl = 'mongodb://user:password@example.test/voicy'
+const privateMessageText = '/start private transcript contents'
+
+const error = new Error(
+  `failed with ${secretTelegramToken} ${secretStripeKey} ${secretMongoUrl}?token=secret`
+)
+error.stack = `Error: ${error.message}\n    at proof (/tmp/report-sanitizer-proof.js:1:1)`
+
+const report = sanitizeErrorReport(error, {
+  location: 'proof',
+  jobId: 'job-123',
+  meta: {
+    workerUrl: `https://example.test/worker?token=${secretTelegramToken}`,
+  },
+  ctx: {
+    update: {
+      update_id: 123,
+      message: {},
+    },
+    chat: {
+      id: -100123,
+      type: 'supergroup',
+    },
+    from: {
+      id: 456,
+    },
+    msg: {
+      message_id: 789,
+      text: privateMessageText,
+    },
+  },
+})
+
+const serialized = JSON.stringify(report)
+
+assert.strictEqual(report.location, 'proof')
+assert.strictEqual(report.jobId, 'job-123')
+assert.strictEqual(report.context.updateId, 123)
+assert.strictEqual(report.context.updateType, 'message')
+assert.strictEqual(report.context.chatId, '-100123')
+assert.strictEqual(report.context.chatType, 'supergroup')
+assert.strictEqual(report.context.userId, '456')
+assert.strictEqual(report.context.messageType, 'text')
+assert.strictEqual(report.context.command, '/start')
+assert(!serialized.includes(secretTelegramToken), 'Telegram token leaked')
+assert(!serialized.includes(secretStripeKey), 'Stripe key leaked')
+assert(!serialized.includes('mongodb://user:password'), 'Mongo password leaked')
+assert(!serialized.includes('private transcript'), 'message text leaked')
+
+console.log('report sanitizer proof passed')

--- a/src/app.ts
+++ b/src/app.ts
@@ -34,6 +34,7 @@ import handleTranscribeAll from './commands/handleTranscribeAll'
 import i18n from '@/helpers/i18n'
 import ignoreOldMessageUpdates from '@/middlewares/ignoreOldMessageUpdates'
 import recordTimeReceived from '@/middlewares/recordTimeReceived'
+import report from '@/helpers/report'
 import startMongo from '@/helpers/startMongo'
 import telegramAllowedUpdates from '@/helpers/telegramAllowedUpdates'
 
@@ -73,7 +74,9 @@ async function runApp() {
   // Callabcks
   bot.callbackQuery(/li.+/, handleSetLanguage)
   // Errors
-  bot.catch(console.error)
+  bot.catch((error) => {
+    report(error.error, { ctx: error.ctx, location: 'bot.catch' })
+  })
   // Start bot
   await bot.init()
   await configureBotCommands()

--- a/src/helpers/report.ts
+++ b/src/helpers/report.ts
@@ -3,9 +3,162 @@ import Context from '@/models/Context'
 interface ExtraErrorInfo {
   ctx?: Context
   location?: string
-  meta?: string
+  jobId?: string
+  meta?: Record<string, boolean | number | string | null | undefined>
 }
 
-export default function report(error: Error, info: ExtraErrorInfo = {}) {
-  console.log(error, info)
+interface RedactedErrorInfo {
+  location?: string
+  error: {
+    name: string
+    message: string
+    stack?: string
+  }
+  context?: {
+    updateId?: number
+    updateType?: string
+    chatId?: string
+    chatType?: string
+    userId?: string
+    messageType?: string
+    command?: string
+  }
+  jobId?: string
+  meta?: ExtraErrorInfo['meta']
 }
+
+export default function report(error: unknown, info: ExtraErrorInfo = {}) {
+  console.error(sanitizeErrorReport(error, info))
+}
+
+function sanitizeErrorReport(
+  error: unknown,
+  info: ExtraErrorInfo = {}
+): RedactedErrorInfo {
+  const report: RedactedErrorInfo = {
+    location: info.location,
+    error: sanitizeError(error),
+    context: sanitizeContext(info.ctx),
+    jobId: info.jobId,
+    meta: sanitizeMeta(info.meta),
+  }
+
+  return compactObject(report) as RedactedErrorInfo
+}
+
+function sanitizeError(error: unknown): RedactedErrorInfo['error'] {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: redactSensitiveText(error.message),
+      stack: error.stack ? redactSensitiveText(error.stack) : undefined,
+    }
+  }
+
+  return {
+    name: typeof error,
+    message: redactSensitiveText(String(error)),
+  }
+}
+
+function sanitizeContext(ctx?: Context): RedactedErrorInfo['context'] {
+  if (!ctx) {
+    return undefined
+  }
+
+  return compactObject({
+    updateId: ctx.update?.update_id,
+    updateType: updateType(ctx.update),
+    chatId: ctx.chat?.id ? String(ctx.chat.id) : undefined,
+    chatType: ctx.chat?.type,
+    userId: ctx.from?.id ? String(ctx.from.id) : undefined,
+    messageType: ctx.msg ? messageType(ctx.msg) : undefined,
+    command: commandName(ctx.msg?.text),
+  })
+}
+
+function updateType(update?: Context['update']) {
+  if (!update) {
+    return undefined
+  }
+
+  return Object.keys(update).find((key) => key !== 'update_id')
+}
+
+function messageType(message: Context['msg']) {
+  if (!message) {
+    return undefined
+  }
+
+  const knownMessageTypes = [
+    'voice',
+    'video_note',
+    'audio',
+    'document',
+    'video',
+    'text',
+    'photo',
+    'sticker',
+    'animation',
+    'contact',
+    'location',
+    'venue',
+    'poll',
+    'dice',
+  ]
+
+  return knownMessageTypes.find((type) => type in message) || 'unknown'
+}
+
+function commandName(text?: string) {
+  if (!text?.startsWith('/')) {
+    return undefined
+  }
+
+  const command = text.split(/\s+/, 1)[0]?.split('@', 1)[0]
+  return command || undefined
+}
+
+function redactSensitiveText(value: string) {
+  return value
+    .replace(/\b\d{5,}:[A-Za-z0-9_-]{20,}\b/g, '[redacted-telegram-token]')
+    .replace(
+      /\b(?:Bearer|Token|Authorization|Api-Key)\s+[^,\s)]+/gi,
+      '[redacted-secret]'
+    )
+    .replace(/\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]+/g, '[redacted-stripe-key]')
+    .replace(/\bwhsec_[A-Za-z0-9]+/g, '[redacted-stripe-secret]')
+    .replace(
+      /(mongodb(?:\+srv)?:\/\/[^:\s/@]+:)[^@\s]+(@)/gi,
+      '$1[redacted-password]$2'
+    )
+    .replace(
+      /([?&](?:token|key|secret|password|signature)=)[^&\s]+/gi,
+      '$1[redacted]'
+    )
+}
+
+function sanitizeMeta(meta?: ExtraErrorInfo['meta']) {
+  if (!meta) {
+    return undefined
+  }
+
+  return Object.keys(meta).reduce((result, key) => {
+    const value = meta[key]
+    result[key] = typeof value === 'string' ? redactSensitiveText(value) : value
+    return result
+  }, {} as ExtraErrorInfo['meta'])
+}
+
+function compactObject<T extends object>(value: T) {
+  return Object.keys(value).reduce((result, key) => {
+    const typedKey = key as keyof T
+    const entry = value[typedKey]
+    if (entry !== undefined) {
+      result[typedKey] = entry
+    }
+    return result
+  }, {} as Partial<T>)
+}
+
+export { sanitizeErrorReport }


### PR DESCRIPTION
## Summary
- replace raw `report(error, info)` output with a structured sanitized error report
- log only scoped Telegram context metadata: update/chat/user ids, update/message type, command, location, and job id
- route global grammY `bot.catch` errors through the sanitizer instead of raw `console.error`
- add a focused report sanitizer proof script

## Validation
- `yarn build-ts`
- `yarn test:report-sanitizer`
- `yarn lint`
- `yarn prettier --check scripts/report-sanitizer-proof.js`

Manual QA: not required. This changes server-side logging shape only and does not alter Telegram user-facing behavior.