### PR TITLE
Handle empty Voicy transcription results

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:language-selection": "node scripts/language-selection-proof.js",
     "test:progress-policy": "node scripts/progress-policy-proof.js",
     "test:progress-status-format": "node scripts/progress-status-format-proof.js",
+    "test:error-empty-handling": "node scripts/error-empty-handling-proof.js",
     "test:media-coverage": "node scripts/media-coverage-proof.js",
     "test:report-sanitizer": "node scripts/report-sanitizer-proof.js",
     "test:source-url-security": "node scripts/source-url-security-proof.js",

--- a/scripts/error-empty-handling-proof.js
+++ b/scripts/error-empty-handling-proof.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+require('module-alias/register')
+
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+
+const { redactSensitiveText } = require('../dist/helpers/report')
+const {
+  transcriptText,
+} = require('../dist/helpers/transcriptionJobs/transcriptFormatting')
+const localizedTranscriptionText = require('../dist/helpers/localizedTranscriptionText')
+  .default
+
+assert.equal(
+  transcriptText({ resultText: '' }),
+  '',
+  'empty completed transcript should remain empty for fallback publishing'
+)
+assert.equal(
+  transcriptText({ resultParts: [] }),
+  '',
+  'empty completed transcript parts should remain empty for fallback publishing'
+)
+assert.equal(
+  localizedTranscriptionText('en', 'completed_empty'),
+  'Done, but no text was detected.',
+  'English empty-result copy should clearly describe no detected text'
+)
+assert.equal(
+  localizedTranscriptionText('ru', 'completed_empty'),
+  'Готово, но текст не найден.',
+  'Russian empty-result copy should clearly describe no detected text'
+)
+
+const sensitive = [
+  '123456789:abcdefghijklmnopqrstuvwxyzABCDE',
+  ['sk', 'live', 'abcdefghijklmnopqrstuvwxyz'].join('_'),
+  ['whsec', 'abcdefghijklmnopqrstuvwxyz'].join('_'),
+  'Bearer worker-secret-token',
+  'https://example.test/file?token=secret',
+  '/Users/nikita/voicy-worker/input.ogg',
+  'C:\\voicy-worker\\input.ogg',
+].join(' ')
+const redacted = redactSensitiveText(sensitive)
+
+assert(!redacted.includes('123456789:'), 'Telegram token should be redacted')
+assert(!redacted.includes('sk_live_'), 'Stripe key should be redacted')
+assert(!redacted.includes('whsec_'), 'Stripe webhook secret should be redacted')
+assert(!redacted.includes('worker-secret-token'), 'bearer token should be redacted')
+assert(!redacted.includes('token=secret'), 'query token should be redacted')
+assert(!redacted.includes('/Users/nikita'), 'POSIX local path should be redacted')
+assert(!redacted.includes('C:\\voicy-worker'), 'Windows local path should be redacted')
+
+const publishSource = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    'src',
+    'helpers',
+    'transcriptionJobs',
+    'publishCompletedTranscriptionJob.ts'
+  ),
+  'utf8'
+)
+
+assert(
+  publishSource.includes('firstText || fallbackText'),
+  'completed publisher should use empty-result fallback text'
+)
+assert(
+  !publishSource.includes('editMessageCaption'),
+  'completed publisher should not mutate original media captions'
+)
+
+console.log('error and empty handling proof passed')

--- a/scripts/report-sanitizer-proof.js
+++ b/scripts/report-sanitizer-proof.js
@@ -7,10 +7,12 @@ const secretTelegramToken = [
 ].join(':')
 const secretStripeKey = ['sk', 'live', 'abcdefghijklmnopqrstuvwxyz'].join('_')
 const secretMongoUrl = 'mongodb://user:password@example.test/voicy'
+const localPosixPath = '/Users/nikita/voicy-worker/input.ogg'
+const localWindowsPath = 'C:\\voicy-worker\\input.ogg'
 const privateMessageText = '/start private transcript contents'
 
 const error = new Error(
-  `failed with ${secretTelegramToken} ${secretStripeKey} ${secretMongoUrl}?token=secret`
+  `failed with ${secretTelegramToken} ${secretStripeKey} ${secretMongoUrl}?token=secret ${localPosixPath} ${localWindowsPath}`
 )
 error.stack = `Error: ${error.message}\n    at proof (/tmp/report-sanitizer-proof.js:1:1)`
 
@@ -53,6 +55,8 @@ assert.strictEqual(report.context.command, '/start')
 assert(!serialized.includes(secretTelegramToken), 'Telegram token leaked')
 assert(!serialized.includes(secretStripeKey), 'Stripe key leaked')
 assert(!serialized.includes('mongodb://user:password'), 'Mongo password leaked')
+assert(!serialized.includes(localPosixPath), 'POSIX local path leaked')
+assert(!serialized.includes(localWindowsPath), 'Windows local path leaked')
 assert(!serialized.includes('private transcript'), 'message text leaked')
 
 console.log('report sanitizer proof passed')

--- a/scripts/worker-api-proof.js
+++ b/scripts/worker-api-proof.js
@@ -243,6 +243,62 @@ async function main() {
       'result text missing'
     )
 
+    const emptyJob = await TranscriptionJobModel.create({
+      chatId: 'proof-chat',
+      telegramChatId: '123',
+      sourceMessageId: 13,
+      fileId: 'proof-file-empty',
+      sourceKind: TranscriptionJobSourceKind.voice,
+      sourceUrl: 'https://example.invalid/empty.ogg',
+    })
+    const claimEmpty = await request(baseUrl, '/jobs/claim-download', tokenA, {
+      method: 'POST',
+    })
+    assert(claimEmpty.status === 200, 'empty job should be claimable')
+    const emptyClaim = await claimEmpty.json()
+    assert(emptyClaim.job.id === emptyJob._id.toString(), 'claimed wrong empty job')
+    const emptyDownloaded = await request(
+      baseUrl,
+      `/jobs/${emptyClaim.job.id}/downloaded`,
+      tokenA,
+      {
+        method: 'POST',
+        body: JSON.stringify({ localSourcePath: '/tmp/proof-empty.ogg' }),
+      }
+    )
+    assert(emptyDownloaded.status === 200, 'empty job should mark downloaded')
+    const emptyTranscribe = await request(
+      baseUrl,
+      `/jobs/${emptyClaim.job.id}/transcribe`,
+      tokenA,
+      { method: 'POST' }
+    )
+    assert(emptyTranscribe.status === 200, 'empty job should start transcription')
+    const emptyResult = await request(
+      baseUrl,
+      `/jobs/${emptyClaim.job.id}/result`,
+      tokenA,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          text: '',
+          parts: [],
+          language: 'en',
+          engine: 'proof-engine',
+          duration: 0,
+        }),
+      }
+    )
+    assert(emptyResult.status === 200, 'empty result should be accepted')
+    const completedEmptyJob = await TranscriptionJobModel.findById(
+      emptyClaim.job.id
+    )
+    assert(
+      completedEmptyJob.status === TranscriptionJobStatus.completed,
+      'empty result should complete job'
+    )
+    assert(completedEmptyJob.resultText === '', 'empty result text should persist')
+
     const retryJob = await TranscriptionJobModel.create({
       chatId: 'proof-chat',
       telegramChatId: '123',

--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -494,6 +494,51 @@ async function main() {
     await close(server)
   }
 
+  const emptyProof = createProofServer()
+  await listen(emptyProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${emptyProof.server.address().port}/worker/v1`
+    const config = loadConfig({
+      VOICY_WORKER_API_URL: baseUrl,
+      VOICY_WORKER_TOKEN: 'proof-worker-token',
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        '-e',
+        "process.stdout.write(JSON.stringify({ text: '', parts: [], language: 'en', duration: 0.1 }))",
+      ]),
+      VOICY_WORKER_WORK_DIR: path.join(
+        os.tmpdir(),
+        `voicy-worker-empty-proof-${process.pid}`
+      ),
+      VOICY_WORKER_TELEGRAM_API_URL: `http://127.0.0.1:${
+        emptyProof.server.address().port
+      }`,
+      VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
+    })
+
+    const processed = await processNextJob(config, {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    })
+
+    assert(processed, 'worker should process the empty transcript job')
+    assert(
+      !emptyProof.state.failure,
+      `empty transcript should not report failure: ${JSON.stringify(
+        emptyProof.state.failure
+      )}`
+    )
+    assert(emptyProof.state.result, 'empty transcript should submit a result')
+    assert(
+      emptyProof.state.result.text === '',
+      'empty transcript should submit empty result text for backend fallback copy'
+    )
+  } finally {
+    await close(emptyProof.server)
+  }
+
   const failureProof = createProofServer()
   await listen(failureProof.server)
 

--- a/src/helpers/report.ts
+++ b/src/helpers/report.ts
@@ -136,6 +136,11 @@ function redactSensitiveText(value: string) {
       /([?&](?:token|key|secret|password|signature)=)[^&\s]+/gi,
       '$1[redacted]'
     )
+    .replace(
+      /(^|[\s(["'])(\/(?:Users|home|tmp|var|private|Volumes)\/[^\s,)"']+)/g,
+      '$1[redacted-local-path]'
+    )
+    .replace(/(^|[\s(["'])([A-Za-z]:\\[^\s,)"']+)/g, '$1[redacted-local-path]')
 }
 
 function sanitizeMeta(meta?: ExtraErrorInfo['meta']) {
@@ -161,4 +166,4 @@ function compactObject<T extends object>(value: T) {
   }, {} as Partial<T>)
 }
 
-export { sanitizeErrorReport }
+export { redactSensitiveText, sanitizeErrorReport }

--- a/src/helpers/transcriptionJobs/transcriptFormatting.ts
+++ b/src/helpers/transcriptionJobs/transcriptFormatting.ts
@@ -30,7 +30,9 @@ export function transcriptTextFromParts(
 }
 
 export function transcriptText(job: DocumentType<TranscriptionJob>) {
-  return job.resultText?.trim() || transcriptTextFromParts(job.resultParts)
+  return (
+    job.resultText?.trim() || transcriptTextFromParts(job.resultParts) || ''
+  )
 }
 
 export function partialTranscriptText(job: DocumentType<TranscriptionJob>) {

--- a/src/helpers/workerApi/jobService.ts
+++ b/src/helpers/workerApi/jobService.ts
@@ -57,7 +57,7 @@ function maxAttempts() {
 }
 
 function validateResultText(text: unknown) {
-  if (typeof text !== 'string' || !text.trim()) {
+  if (typeof text !== 'string') {
     throw new WorkerApiError(400, 'result_text_required')
   }
   if (text.length > MAX_RESULT_TEXT_LENGTH) {

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -5,6 +5,7 @@ import { createWriteStream } from 'fs'
 import { mkdir, readFile, stat, unlink } from 'fs/promises'
 import { pipeline } from 'stream'
 import { promisify } from 'util'
+import { redactSensitiveText } from '../helpers/report'
 import { spawn } from 'child_process'
 import axios, { AxiosInstance } from 'axios'
 
@@ -511,11 +512,7 @@ function normalizeTranscriptionOutput(
   inputPath: string
 ) {
   const parsed = parseJsonOutput(rawOutput.trim())
-  const text = parsed?.text || rawOutput.trim()
-
-  if (!text) {
-    throw new WorkerClientError('Transcription command produced no text', false)
-  }
+  const text = typeof parsed?.text === 'string' ? parsed.text : rawOutput.trim()
 
   return {
     text,
@@ -582,7 +579,9 @@ async function failJob(
   logger: Logger
 ) {
   const retryable = error instanceof WorkerClientError ? error.retryable : true
-  const message = error instanceof Error ? error.message : String(error)
+  const message = redactSensitiveText(
+    error instanceof Error ? error.message : String(error)
+  )
   logger.warn(`Reporting job ${jobId} failure: ${message}`)
   await api.post(`/jobs/${jobId}/failure`, { error: message, retryable })
 }
@@ -598,7 +597,9 @@ function startHeartbeat(
   }
   return setInterval(() => {
     api.post(`/jobs/${jobId}/heartbeat`).catch((error) => {
-      const message = error instanceof Error ? error.message : String(error)
+      const message = redactSensitiveText(
+        error instanceof Error ? error.message : String(error)
+      )
       logger.warn(`Heartbeat failed for job ${jobId}: ${message}`)
     })
   }, intervalMs)


### PR DESCRIPTION
## Summary
- allow successful zero-text worker transcription results to complete so Voicy publishes the localized empty-result copy
- keep transcript formatting safe for empty result payloads
- redact local filesystem paths in sanitized reports and worker failure/heartbeat logs/submissions
- add focused empty/error proof coverage across worker client, worker API, sanitizer, and publisher fallback behavior

## Validation
- yarn build-ts
- yarn lint
- yarn test:error-empty-handling
- yarn test:report-sanitizer
- MONGO=mongodb://127.0.0.1:27018/voicy_kaneo_45_worker_api yarn test:worker-api
- yarn test:worker-client
- yarn test:media-coverage
- yarn test:progress-status-format
- yarn audit-locales
- yarn audit:commands

## Manual QA
Required by task: OpenClaw should use Telegram Web/Codex computer use to verify one normal audio, one empty/silent or no-speech fixture if feasible, and one controlled failure path if repo support exists. Expected results: normal audio publishes transcript; empty/no-speech publishes the localized no-text-detected message; controlled final failure publishes the generic localized failure status without mutating original media captions or exposing sensitive details.