### PR TITLE
Fix Voicy draft transcript finalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:language-selection": "node scripts/language-selection-proof.js",
     "test:progress-policy": "node scripts/progress-policy-proof.js",
     "test:progress-status-format": "node scripts/progress-status-format-proof.js",
+    "test:transcription-finalization": "node scripts/transcription-finalization-proof.js",
     "test:error-empty-handling": "node scripts/error-empty-handling-proof.js",
     "test:media-coverage": "node scripts/media-coverage-proof.js",
     "test:report-sanitizer": "node scripts/report-sanitizer-proof.js",

--- a/scripts/error-empty-handling-proof.js
+++ b/scripts/error-empty-handling-proof.js
@@ -104,7 +104,9 @@ assert(
   'completed publisher should use empty-result fallback text'
 )
 assert(
-  publishSource.includes('text: transcriptText(job)'),
+  publishSource.includes('text: transcriptText(job)') &&
+    publishSource.includes('findOneAndUpdate') &&
+    publishSource.includes('upsert: true'),
   'completed voice records should store normalized transcript text'
 )
 assert(

--- a/scripts/transcription-finalization-proof.js
+++ b/scripts/transcription-finalization-proof.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+require('module-alias/register')
+
+const assert = require('assert')
+
+const TRANSCRIPTION_STATUSES = {
+  queuedForDownload: 'queued_for_download',
+  downloading: 'downloading',
+  ready: 'ready',
+  transcribing: 'transcribing',
+  queued: 'queued',
+  processing: 'processing',
+  completed: 'completed',
+  failed: 'failed',
+}
+
+function mockModule(path, exports) {
+  require.cache[path] = {
+    id: path,
+    filename: path,
+    loaded: true,
+    exports,
+  }
+}
+
+function clearModule(path) {
+  delete require.cache[path]
+}
+
+async function provesCompletedPublisherFallsBackToFinalMessage() {
+  const botPath = require.resolve('../dist/helpers/bot')
+  const voicePath = require.resolve('../dist/models/Voice')
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+  )
+  const editCalls = []
+  const deleteCalls = []
+  const sendCalls = []
+  const voiceUpserts = []
+
+  clearModule(publisherPath)
+  mockModule(botPath, {
+    __esModule: true,
+    default: {
+      api: {
+        editMessageText: async (...args) => {
+          editCalls.push(args)
+          throw new Error('simulated Telegram edit failure')
+        },
+        deleteMessage: async (...args) => {
+          deleteCalls.push(args)
+        },
+        sendMessage: async (...args) => {
+          sendCalls.push(args)
+          return { message_id: 999 }
+        },
+      },
+    },
+  })
+  mockModule(voicePath, {
+    VoiceModel: {
+      findOneAndUpdate: async (...args) => {
+        voiceUpserts.push(args)
+        return {}
+      },
+    },
+  })
+
+  const publishCompletedTranscriptionJob = require(publisherPath).default
+
+  await publishCompletedTranscriptionJob({
+    sourceUrl: 'https://example.invalid/audio.ogg',
+    chatId: 'chat-1',
+    telegramChatId: '123',
+    telegramChatType: 'private',
+    sourceMessageId: 10,
+    statusMessageId: 20,
+    fileId: 'file-1',
+    sourceKind: 'voice',
+    resultText: 'final transcript',
+  })
+
+  assert.equal(editCalls.length, 1, 'status message should be edited first')
+  assert.equal(
+    deleteCalls.length,
+    1,
+    'failed edit should trigger stale draft deletion'
+  )
+  assert.equal(sendCalls.length, 1, 'failed edit should send final fallback')
+  assert.equal(sendCalls[0][1], 'final transcript')
+  assert(
+    !sendCalls[0][1].includes('Turning into text') &&
+      !sendCalls[0][1].includes('Draft text'),
+    'fallback final message must not include draft/progress copy'
+  )
+  assert.equal(
+    voiceUpserts.length,
+    1,
+    'completed voice record should be stored after publish recovery'
+  )
+  assert.deepEqual(voiceUpserts[0][0], {
+    chatId: 'chat-1',
+    messageId: 10,
+  })
+  assert.equal(voiceUpserts[0][2].upsert, true)
+}
+
+async function provesCompletionWaitsForPublish() {
+  const jobServicePath = require.resolve('../dist/helpers/workerApi/jobService')
+  const transcriptionJobPath = require.resolve('../dist/models/TranscriptionJob')
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+  )
+  const jobId = '507f1f77bcf86cd799439011'
+  const updates = []
+  const workerClient = { _id: { toString: () => 'worker-1' } }
+
+  clearModule(jobServicePath)
+  mockModule(transcriptionJobPath, {
+    TranscriptionJobStatus: TRANSCRIPTION_STATUSES,
+    TranscriptionJobModel: {
+      findOneAndUpdate: async (...args) => {
+        updates.push(args)
+        if (updates.length === 1) {
+          return {
+            _id: { toString: () => jobId },
+            status: TRANSCRIPTION_STATUSES.transcribing,
+            workerId: 'worker-1',
+            chatId: 'chat-1',
+            telegramChatId: '123',
+            telegramChatType: 'private',
+            sourceMessageId: 10,
+            statusMessageId: 20,
+            fileId: 'file-1',
+            sourceKind: 'voice',
+            resultText: 'final transcript',
+          }
+        }
+        return {
+          _id: { toString: () => jobId },
+          status: TRANSCRIPTION_STATUSES.completed,
+        }
+      },
+    },
+  })
+  mockModule(publisherPath, {
+    __esModule: true,
+    default: async () => undefined,
+  })
+
+  const { completeJob } = require(jobServicePath)
+  const job = await completeJob(jobId, workerClient, {
+    text: 'final transcript',
+  })
+
+  assert.equal(job.status, TRANSCRIPTION_STATUSES.completed)
+  assert.equal(
+    updates[0][1].$set.status,
+    undefined,
+    'result persistence must not mark the job completed before publishing'
+  )
+  assert.equal(
+    updates[1][1].$set.status,
+    TRANSCRIPTION_STATUSES.completed,
+    'job should be completed only after final publish succeeds'
+  )
+}
+
+async function provesPublishFailureLeavesJobRetryable() {
+  const jobServicePath = require.resolve('../dist/helpers/workerApi/jobService')
+  const transcriptionJobPath = require.resolve('../dist/models/TranscriptionJob')
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+  )
+  const jobId = '507f1f77bcf86cd799439012'
+  const updates = []
+  const workerClient = { _id: { toString: () => 'worker-1' } }
+  const originalConsoleError = console.error
+
+  clearModule(jobServicePath)
+  mockModule(transcriptionJobPath, {
+    TranscriptionJobStatus: TRANSCRIPTION_STATUSES,
+    TranscriptionJobModel: {
+      findOneAndUpdate: async (...args) => {
+        updates.push(args)
+        return {
+          _id: { toString: () => jobId },
+          status: TRANSCRIPTION_STATUSES.transcribing,
+          workerId: 'worker-1',
+          chatId: 'chat-1',
+          telegramChatId: '123',
+          telegramChatType: 'private',
+          sourceMessageId: 10,
+          statusMessageId: 20,
+          fileId: 'file-1',
+          sourceKind: 'voice',
+          resultText: 'final transcript',
+        }
+      },
+    },
+  })
+  mockModule(publisherPath, {
+    __esModule: true,
+    default: async () => {
+      throw new Error('publish failed')
+    },
+  })
+
+  const { completeJob } = require(jobServicePath)
+  try {
+    console.error = () => undefined
+    await assert.rejects(
+      () => completeJob(jobId, workerClient, { text: 'final transcript' }),
+      /publish failed/
+    )
+  } finally {
+    console.error = originalConsoleError
+  }
+
+  assert.equal(updates.length, 1)
+  assert.equal(
+    updates[0][1].$set.status,
+    undefined,
+    'publish failure must not convert an in-progress job into completed'
+  )
+}
+
+async function main() {
+  await provesCompletedPublisherFallsBackToFinalMessage()
+  await provesCompletionWaitsForPublish()
+  await provesPublishFailureLeavesJobRetryable()
+  console.log('transcription finalization proof passed')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
+++ b/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
@@ -9,43 +9,67 @@ import bot from '@/helpers/bot'
 import localizedTranscriptionText from '@/helpers/localizedTranscriptionText'
 
 async function storeVoiceRecord(job: DocumentType<TranscriptionJob>) {
-  await VoiceModel.create({
-    url: job.sourceUrl || job.localSourcePath || job.filePath || job.fileId,
-    status: 'completed',
-    chatId: job.chatId,
-    messageId: job.sourceMessageId,
-    ackMessageId: job.statusMessageId,
-    fileId: job.fileId,
-    fileSize: job.fileSize,
-    mimeType: job.mimeType,
-    fileName: job.fileName,
-    sourceType: job.sourceKind,
-    requestedBy: job.requestedByUserId
-      ? Number(job.requestedByUserId)
-      : undefined,
-    forwardFromId: job.forwardedFromUserId
-      ? Number(job.forwardedFromUserId)
-      : undefined,
-    forwardSenderName: job.forwardedSenderName,
-    claimedAt: job.claimedAt,
-    completedAt: job.completedAt || new Date(),
-    duration: job.duration || 0,
-    language: job.recognitionLanguage || job.recognitionLanguageHint || 'auto',
-    text: transcriptText(job),
-    textWithTimecodes: job.resultParts?.map((part) => [
-      part.timeCode || '',
-      part.text,
-    ]),
-    workerEngine: job.workerEngine,
-  })
+  await VoiceModel.findOneAndUpdate(
+    { chatId: job.chatId, messageId: job.sourceMessageId },
+    {
+      $set: {
+        url: job.sourceUrl || job.localSourcePath || job.filePath || job.fileId,
+        status: 'completed',
+        chatId: job.chatId,
+        messageId: job.sourceMessageId,
+        ackMessageId: job.statusMessageId,
+        fileId: job.fileId,
+        fileSize: job.fileSize,
+        mimeType: job.mimeType,
+        fileName: job.fileName,
+        sourceType: job.sourceKind,
+        requestedBy: job.requestedByUserId
+          ? Number(job.requestedByUserId)
+          : undefined,
+        forwardFromId: job.forwardedFromUserId
+          ? Number(job.forwardedFromUserId)
+          : undefined,
+        forwardSenderName: job.forwardedSenderName,
+        claimedAt: job.claimedAt,
+        completedAt: job.completedAt || new Date(),
+        duration: job.duration || 0,
+        language:
+          job.recognitionLanguage || job.recognitionLanguageHint || 'auto',
+        text: transcriptText(job),
+        textWithTimecodes: job.resultParts?.map((part) => [
+          part.timeCode || '',
+          part.text,
+        ]),
+        workerEngine: job.workerEngine,
+      },
+    },
+    { upsert: true }
+  )
+}
+
+function telegramErrorDescription(error: unknown) {
+  return error && typeof error === 'object' && 'description' in error
+    ? String((error as { description?: string }).description)
+    : ''
+}
+
+async function deleteStatusMessage(job: DocumentType<TranscriptionJob>) {
+  if (!job.statusMessageId) {
+    return
+  }
+
+  try {
+    await bot.api.deleteMessage(job.telegramChatId, job.statusMessageId)
+  } catch (error) {
+    console.error('Failed to delete stale transcription status message', error)
+  }
 }
 
 export default async function publishCompletedTranscriptionJob(
   job: DocumentType<TranscriptionJob>
 ) {
-  await storeVoiceRecord(job)
-
   if (process.env.VOICY_DISABLE_TELEGRAM_PUBLISH === '1') {
+    await storeVoiceRecord(job)
     return
   }
 
@@ -61,11 +85,26 @@ export default async function publishCompletedTranscriptionJob(
       : { reply_to_message_id: job.sourceMessageId }
 
   if (job.statusMessageId) {
-    await bot.api.editMessageText(
-      job.telegramChatId,
-      job.statusMessageId,
-      firstText || fallbackText
-    )
+    try {
+      await bot.api.editMessageText(
+        job.telegramChatId,
+        job.statusMessageId,
+        firstText || fallbackText
+      )
+    } catch (error) {
+      if (
+        !telegramErrorDescription(error).includes('message is not modified')
+      ) {
+        await deleteStatusMessage(job)
+        await bot.api.sendMessage(
+          job.telegramChatId,
+          firstText || fallbackText,
+          {
+            ...replyOptions,
+          }
+        )
+      }
+    }
   } else {
     await bot.api.sendMessage(job.telegramChatId, firstText || fallbackText, {
       ...replyOptions,
@@ -77,4 +116,6 @@ export default async function publishCompletedTranscriptionJob(
       ...replyOptions,
     })
   }
+
+  await storeVoiceRecord(job)
 }

--- a/src/helpers/workerApi/jobService.ts
+++ b/src/helpers/workerApi/jobService.ts
@@ -467,7 +467,6 @@ export async function completeJob(
     },
     {
       $set: {
-        status: TranscriptionJobStatus.completed,
         resultText,
         resultParts,
         recognitionLanguage,
@@ -475,7 +474,6 @@ export async function completeJob(
         duration,
         workerEngineMetadata,
         heartbeatAt: now,
-        completedAt: now,
       },
       $unset: { lastError: '' },
     },
@@ -489,8 +487,34 @@ export async function completeJob(
     await publishCompletedTranscriptionJob(job)
   } catch (error) {
     console.error('Failed to publish completed transcription job', error)
+    throw error
   }
-  return job
+
+  const completedJob = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      _id: jobId,
+      workerId: workerId(workerClient),
+      status: {
+        $in: [
+          TranscriptionJobStatus.transcribing,
+          TranscriptionJobStatus.processing,
+        ],
+      },
+    },
+    {
+      $set: {
+        status: TranscriptionJobStatus.completed,
+        heartbeatAt: now,
+        completedAt: now,
+      },
+      $unset: { lastError: '' },
+    },
+    { new: true }
+  )
+  if (!completedJob) {
+    throw new WorkerApiError(404, 'job_not_found')
+  }
+  return completedJob
 }
 
 export async function failJob(


### PR DESCRIPTION
## Summary
- make completed transcript publishing recover when editing the existing draft/status message fails by deleting the stale draft when possible and sending a final fallback message without draft copy
- store completed `Voice` records idempotently so retry/recovery paths do not create duplicate legacy records
- mark `TranscriptionJob` as completed only after final Telegram publish succeeds; publish failures leave the job in a worker-owned active state so the existing worker failure/retry path can recover instead of leaving an indefinite draft
- add `yarn test:transcription-finalization` covering edit fallback, partial-to-final ordering, and publish-failure retryability

## Validation
Automated checks run:
- `yarn build-ts` - passed
- `yarn lint` - passed
- `yarn test:transcription-finalization` - passed
- `yarn test:progress-status-format` - passed
- `yarn test:progress-policy` - passed
- `yarn test:error-empty-handling` - passed
- `MONGO=mongodb://127.0.0.1:27018/voicy_kaneo_46_worker_api yarn test:worker-api` - passed
- `MONGO=mongodb://127.0.0.1:27018/voicy_kaneo_46_worker_e2e yarn test:worker-e2e` - passed
- `yarn test:worker-client` - passed

Manual Telegram QA run:
- Environment: local branch runtime against `@okamikron_bot`, Mongo `mongodb://127.0.0.1:27018/voicy_kaneo_46_telegram`, Chrome CDP `http://127.0.0.1:9222`.
- Uploaded sample audio with `yarn qa:telegram-upload --browser-url http://127.0.0.1:9222 --chat @okamikron_bot --sample --caption "VOI-KANEO-46 finalization QA retry 2026-05-06T16:39:28Z" --expected-text "Turning into text" --send --timeout-ms 180000 --evidence-file tmp/telegram-kaneo-46-upload.json --screenshot-file tmp/telegram-kaneo-46-upload.png --json`.
- Drove worker API through claim/downloaded/transcribe/progress/result for job `69fb6ec369ceb49a6e055884`; progress text produced a visible draft, final result was `VOI-KANEO-46 final transcript without draft footer`.
- CDP verification saved `tmp/telegram-kaneo-46-final.json` and `tmp/telegram-kaneo-46-final.png`; result: `verifiedFinal: true`, `finalStillHasProcessingHeader: false`, `finalStillHasDraftFooter: false`.
