### PR TITLE
Send chat action for silent transcription queueing

### DIFF
--- a/scripts/donation-wall-proof.js
+++ b/scripts/donation-wall-proof.js
@@ -167,6 +167,22 @@ async function main() {
   })
 
   await withPatchedQueue(async (createdJobs) => {
+    process.env.VOICY_DONATION_WALL_ENABLED = 'false'
+    const ctx = mockContext({ paid: true, chatType: 'private' })
+    ctx.dbchat.silent = true
+    await handleAudio(ctx)
+
+    assert(createdJobs.length === 1, 'silent audio should enqueue')
+    assert(ctx.replies.length === 0, 'silent enqueue should not reply')
+    assert(
+      ctx.chatActions.length === 1,
+      'silent enqueue should send a chat action'
+    )
+    assert(ctx.chatActions[0].chatId === 12345, 'chat action targets chat')
+    assert(ctx.chatActions[0].action === 'typing', 'chat action is typing')
+  })
+
+  await withPatchedQueue(async (createdJobs) => {
     process.env.VOICY_DONATION_WALL_ENABLED = 'true'
     const ctx = mockContext({ paid: false, chatType: 'private' })
     await handleAudio(ctx)

--- a/scripts/donation-wall-proof.js
+++ b/scripts/donation-wall-proof.js
@@ -30,20 +30,44 @@ function assert(condition, message) {
   }
 }
 
-function mockContext({ paid, chatType = 'channel', text = '/donate' }) {
+function telegramError(error_code, description) {
+  const error = new Error(description)
+  error.error_code = error_code
+  error.description = description
+  return error
+}
+
+function mockContext({
+  paid,
+  chatType = 'channel',
+  text = '/donate',
+  sendChatActionError,
+}) {
   const replies = []
   const chatActions = []
+  const chatSaves = []
+  const dbchat = {
+    id: `donation-wall-proof-${paid ? 'paid' : 'unpaid'}`,
+    paid,
+    transcribeAllAudio: true,
+    uiLanguage: 'en',
+    silent: false,
+    save: async () => {
+      chatSaves.push({
+        botCanSendMessages: dbchat.botCanSendMessages,
+        transcriptionDisabledUntilReachable:
+          dbchat.transcriptionDisabledUntilReachable,
+        transcriptionUnreachableReason: dbchat.transcriptionUnreachableReason,
+        transcriptionUnreachableAt: dbchat.transcriptionUnreachableAt,
+      })
+    },
+  }
 
   return {
     replies,
     chatActions,
-    dbchat: {
-      id: `donation-wall-proof-${paid ? 'paid' : 'unpaid'}`,
-      paid,
-      transcribeAllAudio: true,
-      uiLanguage: 'en',
-      silent: false,
-    },
+    chatSaves,
+    dbchat,
     chat: { id: 12345, type: chatType },
     from: { id: 67890 },
     msg: {
@@ -64,6 +88,9 @@ function mockContext({ paid, chatType = 'channel', text = '/donate' }) {
     api: {
       sendChatAction: async (chatId, action) => {
         chatActions.push({ chatId, action })
+        if (sendChatActionError) {
+          throw sendChatActionError
+        }
       },
     },
     reply: async (text, options) => {
@@ -99,11 +126,19 @@ async function withPatchedQueue(callback, accessResult) {
   const createdJobs = []
 
   TranscriptionJobModel.create = async (job) => {
-    createdJobs.push(job)
-    return {
+    const jobDoc = {
       ...job,
-      save: async () => undefined,
+      saves: [],
+      save: async () => {
+        jobDoc.saves.push({
+          status: jobDoc.status,
+          failedAt: jobDoc.failedAt,
+          lastError: jobDoc.lastError,
+        })
+      },
     }
+    createdJobs.push(jobDoc)
+    return jobDoc
   }
   abuseLimits.checkTranscriptionAbuseLimits = async () => undefined
   goldenBorodutchAllowance.checkTranscriptionAccess = async () =>
@@ -183,24 +218,79 @@ async function main() {
   })
 
   await withPatchedQueue(async (createdJobs) => {
-    process.env.VOICY_DONATION_WALL_ENABLED = 'true'
-    const ctx = mockContext({ paid: false, chatType: 'private' })
+    process.env.VOICY_DONATION_WALL_ENABLED = 'false'
+    const ctx = mockContext({
+      paid: true,
+      chatType: 'private',
+      sendChatActionError: telegramError(
+        400,
+        'Bad Request: not enough rights to send messages'
+      ),
+    })
+    ctx.dbchat.silent = true
     await handleAudio(ctx)
 
-    assert(createdJobs.length === 0, 'enabled wall should block unpaid audio')
     assert(
-      ctx.replies.length === 1,
-      'enabled wall should send subscriber guidance'
+      createdJobs.length === 1,
+      'silent audio should create the job before chat action'
     )
     assert(
-      ctx.replies[0].text === 'golden_borodutch_subscription_required',
-      'subscriber copy should be used'
+      ctx.replies.length === 0,
+      'silent chat action failure should not reply'
     )
-  }, {
-    allowed: false,
-    consumedFreeTranscription: false,
-    reason: 'subscription_required',
+    assert(
+      ctx.chatActions.length === 1,
+      'silent chat action failure should still attempt one chat action'
+    )
+    assert(
+      ctx.chatSaves.length === 1,
+      'permanent chat action failure should mark chat unreachable'
+    )
+    assert(
+      ctx.dbchat.transcriptionDisabledUntilReachable === true,
+      'chat should be blocked from future queueing'
+    )
+    assert(
+      createdJobs[0].status === TranscriptionJobStatus.failed,
+      'permanent chat action failure should fail the queued job'
+    )
+    assert(
+      createdJobs[0].failedAt instanceof Date,
+      'failed silent job should record failedAt'
+    )
+    assert(
+      createdJobs[0].lastError ===
+        'Telegram chat is unreachable for transcription',
+      'failed silent job should record unreachable reason'
+    )
+    assert(
+      createdJobs[0].saves.length === 1,
+      'failed silent job should be saved'
+    )
   })
+
+  await withPatchedQueue(
+    async (createdJobs) => {
+      process.env.VOICY_DONATION_WALL_ENABLED = 'true'
+      const ctx = mockContext({ paid: false, chatType: 'private' })
+      await handleAudio(ctx)
+
+      assert(createdJobs.length === 0, 'enabled wall should block unpaid audio')
+      assert(
+        ctx.replies.length === 1,
+        'enabled wall should send subscriber guidance'
+      )
+      assert(
+        ctx.replies[0].text === 'golden_borodutch_subscription_required',
+        'subscriber copy should be used'
+      )
+    },
+    {
+      allowed: false,
+      consumedFreeTranscription: false,
+      reason: 'subscription_required',
+    }
+  )
 
   await withPatchedStripeCheckout(async (createdSessions) => {
     process.env.VOICY_DONATION_WALL_ENABLED = 'false'

--- a/scripts/silent-mode-proof.js
+++ b/scripts/silent-mode-proof.js
@@ -321,12 +321,69 @@ async function provesSilentCompletionOmitsTimecodes() {
   )
 }
 
+async function provesSilentCompletionPrefersPartsWhenRawTextHasTimecodes() {
+  const botPath = require.resolve('../dist/helpers/bot')
+  const voicePath = require.resolve('../dist/models/Voice')
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+  )
+  const editCalls = []
+  const voiceUpserts = []
+
+  clearModule(publisherPath)
+  mockModule(botPath, {
+    __esModule: true,
+    default: {
+      api: {
+        editMessageText: async (...args) => {
+          editCalls.push(args)
+        },
+      },
+    },
+  })
+  mockModule(voicePath, {
+    VoiceModel: {
+      findOneAndUpdate: async (...args) => {
+        voiceUpserts.push(args)
+      },
+    },
+  })
+
+  const publishCompletedTranscriptionJob = require(publisherPath).default
+  await publishCompletedTranscriptionJob({
+    silent: true,
+    chatId: 'chat-1',
+    telegramChatId: '123',
+    telegramChatType: 'private',
+    sourceMessageId: 10,
+    statusMessageId: 777,
+    fileId: 'file-1',
+    sourceKind: 'voice',
+    resultText: '00:00:\nRaw first chunk.\n00:02:\nRaw second chunk.',
+    resultParts: [
+      { timeCode: '00:00', text: 'Raw first chunk.' },
+      { timeCode: '00:02', text: 'Raw second chunk.' },
+    ],
+  })
+
+  assert.equal(editCalls.length, 1)
+  assert.equal(editCalls[0][2], 'Raw first chunk.\nRaw second chunk.')
+  assert(!editCalls[0][2].includes('00:00:'))
+  assert(!editCalls[0][2].includes('00:02:'))
+  assert.equal(voiceUpserts.length, 1)
+  assert(
+    voiceUpserts[0][1].$set.text.includes('00:00:'),
+    'regular stored transcript text should retain timecodes'
+  )
+}
+
 async function main() {
   await provesSilentProgressStartsWithTranscriptText()
   await provesSilentProgressEditsOneTimecodeFreeMessage()
   await provesSilentCompletionSuppressesEmptyFallback()
   await provesSilentCompletionSendsFinalTranscript()
   await provesSilentCompletionOmitsTimecodes()
+  await provesSilentCompletionPrefersPartsWhenRawTextHasTimecodes()
   console.log('silent mode proof passed')
 }
 

--- a/scripts/silent-mode-proof.js
+++ b/scripts/silent-mode-proof.js
@@ -86,6 +86,74 @@ async function provesSilentProgressStartsWithTranscriptText() {
   ])
 }
 
+async function provesSilentProgressEditsOneTimecodeFreeMessage() {
+  const botPath = require.resolve('../dist/helpers/bot')
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishTranscriptionJobProgress'
+  )
+  const sendCalls = []
+  const editCalls = []
+
+  clearModule(publisherPath)
+  mockModule(botPath, {
+    __esModule: true,
+    default: {
+      api: {
+        sendMessage: async (...args) => {
+          sendCalls.push(args)
+          return { message_id: 777 }
+        },
+        editMessageText: async (...args) => {
+          editCalls.push(args)
+        },
+      },
+    },
+  })
+
+  const publishTranscriptionJobProgress = require(publisherPath).default
+  let saveCount = 0
+  const job = {
+    silent: true,
+    telegramChatId: '123',
+    telegramChatType: 'private',
+    sourceMessageId: 10,
+    uiLocale: 'en',
+    partialResultParts: [
+      { timeCode: '00:00', text: 'First transcript chunk.' },
+      { timeCode: '00:02', text: 'Second transcript chunk.' },
+    ],
+    save: async () => {
+      saveCount += 1
+    },
+  }
+
+  assert.equal(await publishTranscriptionJobProgress(job, 'partial'), true)
+  job.partialResultParts = [
+    { timeCode: '00:00', text: 'First transcript chunk.' },
+    { timeCode: '00:02', text: 'Second transcript chunk.' },
+    { timeCode: '00:04', text: 'Third transcript chunk.' },
+  ]
+  job.lastProgressPublishedAt = new Date(Date.now() - 60_000)
+  assert.equal(await publishTranscriptionJobProgress(job, 'partial'), true)
+
+  assert.equal(sendCalls.length, 1)
+  assert.equal(editCalls.length, 1)
+  assert.equal(sendCalls[0][0], '123')
+  assert.equal(sendCalls[0][2].reply_to_message_id, 10)
+  assert(!sendCalls[0][1].includes('00:00:'))
+  assert(!sendCalls[0][1].includes('00:02:'))
+  assert(sendCalls[0][1].includes('First transcript chunk.'))
+  assert(sendCalls[0][1].includes('Second transcript chunk.'))
+  assert.equal(job.statusMessageId, 777)
+  assert.deepEqual(editCalls[0], [
+    '123',
+    777,
+    'First transcript chunk.\nSecond transcript chunk.\nThird transcript chunk.',
+    { parse_mode: 'HTML' },
+  ])
+  assert.equal(saveCount, 2)
+}
+
 async function provesSilentCompletionSuppressesEmptyFallback() {
   const botPath = require.resolve('../dist/helpers/bot')
   const voicePath = require.resolve('../dist/models/Voice')
@@ -194,10 +262,71 @@ async function provesSilentCompletionSendsFinalTranscript() {
   assert.equal(voiceUpserts.length, 1)
 }
 
+async function provesSilentCompletionOmitsTimecodes() {
+  const botPath = require.resolve('../dist/helpers/bot')
+  const voicePath = require.resolve('../dist/models/Voice')
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+  )
+  const editCalls = []
+  const voiceUpserts = []
+
+  clearModule(publisherPath)
+  mockModule(botPath, {
+    __esModule: true,
+    default: {
+      api: {
+        editMessageText: async (...args) => {
+          editCalls.push(args)
+        },
+      },
+    },
+  })
+  mockModule(voicePath, {
+    VoiceModel: {
+      findOneAndUpdate: async (...args) => {
+        voiceUpserts.push(args)
+      },
+    },
+  })
+
+  const publishCompletedTranscriptionJob = require(publisherPath).default
+  await publishCompletedTranscriptionJob({
+    silent: true,
+    chatId: 'chat-1',
+    telegramChatId: '123',
+    telegramChatType: 'private',
+    sourceMessageId: 10,
+    statusMessageId: 777,
+    fileId: 'file-1',
+    sourceKind: 'voice',
+    resultParts: [
+      { timeCode: '00:00', text: 'Final first chunk.' },
+      { timeCode: '00:02', text: 'Final second chunk.' },
+    ],
+  })
+
+  assert.equal(editCalls.length, 1)
+  assert.deepEqual(editCalls[0], [
+    '123',
+    777,
+    'Final first chunk.\nFinal second chunk.',
+  ])
+  assert(!editCalls[0][2].includes('00:00:'))
+  assert(!editCalls[0][2].includes('00:02:'))
+  assert.equal(voiceUpserts.length, 1)
+  assert(
+    voiceUpserts[0][1].$set.text.includes('00:00:'),
+    'stored history can keep timecoded transcript text'
+  )
+}
+
 async function main() {
   await provesSilentProgressStartsWithTranscriptText()
+  await provesSilentProgressEditsOneTimecodeFreeMessage()
   await provesSilentCompletionSuppressesEmptyFallback()
   await provesSilentCompletionSendsFinalTranscript()
+  await provesSilentCompletionOmitsTimecodes()
   console.log('silent mode proof passed')
 }
 

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -148,6 +148,7 @@ async function enqueueTranscription(
   }
 
   if (ctx.dbchat.silent) {
+    await sendSilentTranscriptionChatAction(ctx)
     console.info('Skipping live transcription status message in silent mode')
     return queuedJob
   }
@@ -268,6 +269,22 @@ function sourceKind(sourceType: TranscribableTelegramFile['sourceType']) {
 
 function fileUniqueId(audio: TranscribableTelegramFile) {
   return 'file_unique_id' in audio ? audio.file_unique_id : undefined
+}
+
+async function sendSilentTranscriptionChatAction(ctx: Context) {
+  if (ctx.chat.type === 'channel') {
+    return
+  }
+
+  try {
+    await ctx.api.sendChatAction(ctx.chat.id, 'typing')
+  } catch (error) {
+    await markChatUnreachableForTelegramError(ctx, error, {
+      location: 'sendSilentTranscriptionChatAction',
+      action: 'sendChatAction',
+    })
+    report(error, { ctx, location: 'sendSilentTranscriptionChatAction' })
+  }
 }
 
 async function sendQueueError(ctx: Context) {

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -148,7 +148,13 @@ async function enqueueTranscription(
   }
 
   if (ctx.dbchat.silent) {
-    await sendSilentTranscriptionChatAction(ctx)
+    const markedUnreachable = await sendSilentTranscriptionChatAction(ctx)
+    if (markedUnreachable) {
+      queuedJob.status = TranscriptionJobStatus.failed
+      queuedJob.failedAt = new Date()
+      queuedJob.lastError = 'Telegram chat is unreachable for transcription'
+      await queuedJob.save()
+    }
     console.info('Skipping live transcription status message in silent mode')
     return queuedJob
   }
@@ -273,17 +279,23 @@ function fileUniqueId(audio: TranscribableTelegramFile) {
 
 async function sendSilentTranscriptionChatAction(ctx: Context) {
   if (ctx.chat.type === 'channel') {
-    return
+    return false
   }
 
   try {
     await ctx.api.sendChatAction(ctx.chat.id, 'typing')
+    return false
   } catch (error) {
-    await markChatUnreachableForTelegramError(ctx, error, {
-      location: 'sendSilentTranscriptionChatAction',
-      action: 'sendChatAction',
-    })
+    const markedUnreachable = await markChatUnreachableForTelegramError(
+      ctx,
+      error,
+      {
+        location: 'sendSilentTranscriptionChatAction',
+        action: 'sendChatAction',
+      }
+    )
     report(error, { ctx, location: 'sendSilentTranscriptionChatAction' })
+    return markedUnreachable
   }
 }
 

--- a/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
+++ b/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
@@ -72,7 +72,9 @@ export default async function publishCompletedTranscriptionJob(
     return
   }
 
-  const finalText = transcriptText(job).trim()
+  const finalText = transcriptText(job, {
+    includeTimecodes: !job.silent,
+  }).trim()
   if (job.silent && !finalText) {
     await deleteStatusMessage(job)
     await storeVoiceRecord(job)

--- a/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
+++ b/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
@@ -60,7 +60,7 @@ export default async function publishTranscriptionJobProgress(
     }
 
     const text = silentTranscriptionProgressPreviewHtml(
-      partialTranscriptText(job)
+      partialTranscriptText(job, { includeTimecodes: false })
     )
     if (!text) {
       return false

--- a/src/helpers/transcriptionJobs/transcriptFormatting.ts
+++ b/src/helpers/transcriptionJobs/transcriptFormatting.ts
@@ -95,11 +95,12 @@ export function transcriptText(
     return typeof structured.text === 'string' ? structured.text.trim() : ''
   }
 
-  return (
-    job.resultText?.trim() ||
-    transcriptTextFromParts(job.resultParts, '', options) ||
-    ''
-  )
+  const partsText = transcriptTextFromParts(job.resultParts, '', options)
+  if (options.includeTimecodes === false && partsText) {
+    return partsText
+  }
+
+  return job.resultText?.trim() || partsText || ''
 }
 
 export function partialTranscriptText(

--- a/src/helpers/transcriptionJobs/transcriptFormatting.ts
+++ b/src/helpers/transcriptionJobs/transcriptFormatting.ts
@@ -16,18 +16,25 @@ type StructuredTranscriptResult = {
   parts?: unknown
 }
 
+type TranscriptTextOptions = {
+  includeTimecodes?: boolean
+}
+
 export function splitTelegramText(text: string) {
   return text.match(new RegExp(`[\\s\\S]{1,${TELEGRAM_MESSAGE_LIMIT}}`, 'g'))
 }
 
 export function transcriptTextFromParts(
   parts?: TranscriptionResultPart[],
-  fallback = ''
+  fallback = '',
+  { includeTimecodes = true }: TranscriptTextOptions = {}
 ) {
   if (parts?.length) {
     return parts
       .map((part) =>
-        part.timeCode ? `${part.timeCode}:\n${part.text}` : part.text
+        includeTimecodes && part.timeCode
+          ? `${part.timeCode}:\n${part.text}`
+          : part.text
       )
       .join('\n')
   }
@@ -71,11 +78,16 @@ function structuredTranscriptParts(parts: unknown) {
     .filter(Boolean) as TranscriptionResultPart[]
 }
 
-export function transcriptText(job: DocumentType<TranscriptionJob>) {
+export function transcriptText(
+  job: DocumentType<TranscriptionJob>,
+  options: TranscriptTextOptions = {}
+) {
   const structured = parseStructuredTranscriptResult(job.resultText)
   if (structured) {
     const partsText = transcriptTextFromParts(
-      structuredTranscriptParts(structured.parts)
+      structuredTranscriptParts(structured.parts),
+      '',
+      options
     )
     if (partsText) {
       return partsText
@@ -84,14 +96,20 @@ export function transcriptText(job: DocumentType<TranscriptionJob>) {
   }
 
   return (
-    job.resultText?.trim() || transcriptTextFromParts(job.resultParts) || ''
+    job.resultText?.trim() ||
+    transcriptTextFromParts(job.resultParts, '', options) ||
+    ''
   )
 }
 
-export function partialTranscriptText(job: DocumentType<TranscriptionJob>) {
+export function partialTranscriptText(
+  job: DocumentType<TranscriptionJob>,
+  options: TranscriptTextOptions = {}
+) {
   return transcriptTextFromParts(
     job.partialResultParts,
-    job.partialResultText || job.resultText || ''
+    job.partialResultText || job.resultText || '',
+    options
   )
 }
 


### PR DESCRIPTION
## Summary
- send a best-effort Telegram `typing` chat action when a `/silent` chat queues accepted media for transcription
- keep silent queueing reply-free and skip chat actions for channels/rejected media
- keep silent streaming to one visible transcript message by sending the first real chunk and editing that same message for later chunks
- omit visible `MM:SS:` timecode prefixes from `/silent` partial and final transcript output while preserving stored timecoded metadata
- rework: ensure silent final output also stays timecode-free when workers submit both raw `resultText` and structured `resultParts`
- rework: when silent `sendChatAction` hits a permanent Telegram permission failure, mark the chat unreachable and fail the just-created transcription job so workers do not burn compute for that chat

## Validation
- `yarn build-ts`
- `yarn test:silent-mode`
- `yarn test:donation-wall`
- `yarn test:chat-reachability`
- `yarn test:transcription-finalization`
- `yarn test:progress-status-format`
- `yarn test:error-empty-handling`
- `yarn lint`
- `npx prettier --check scripts/silent-mode-proof.js scripts/donation-wall-proof.js`

Manual QA: required before closing because the Kaneo task explicitly asks for live Telegram evidence. I did not run it from this workspace because there is no local `.env`/Mongo config here and another Voicy long-polling process is already running against `@okamikron_bot`; starting a second bot with the same token would risk update conflicts. Use Chrome CDP at `http://127.0.0.1:9222`, target `@okamikron_bot`, enable `/silent`, send a voice/audio fixture, and verify no generic progress text appears, Telegram native activity is observable while queueing/processing when possible, later partial/final updates stay in one transcript reply when editing is possible, visible output has no `MM:SS:` prefixes, and final transcript appears on success.
