### PR TITLE
Fix silent progress message race

### DIFF
--- a/scripts/silent-mode-proof.js
+++ b/scripts/silent-mode-proof.js
@@ -154,6 +154,73 @@ async function provesSilentProgressEditsOneTimecodeFreeMessage() {
   assert.equal(saveCount, 2)
 }
 
+async function provesSilentProgressClaimsFirstMessageAtomically() {
+  const botPath = require.resolve('../dist/helpers/bot')
+  const modelPath = require.resolve('../dist/models/TranscriptionJob')
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishTranscriptionJobProgress'
+  )
+  const sendCalls = []
+  const updateCalls = []
+  let claimAvailable = true
+
+  clearModule(publisherPath)
+  mockModule(botPath, {
+    __esModule: true,
+    default: {
+      api: {
+        sendMessage: async (...args) => {
+          sendCalls.push(args)
+          return { message_id: 901 }
+        },
+      },
+    },
+  })
+  mockModule(modelPath, {
+    TranscriptionJobModel: {
+      findOneAndUpdate: async (...args) => {
+        updateCalls.push(['findOneAndUpdate', ...args])
+        if (!claimAvailable) {
+          return null
+        }
+        claimAvailable = false
+        return { _id: 'job-1' }
+      },
+      updateOne: async (...args) => {
+        updateCalls.push(['updateOne', ...args])
+      },
+    },
+  })
+
+  const publishTranscriptionJobProgress = require(publisherPath).default
+  const makeJob = (partialResultText) => ({
+    _id: 'job-1',
+    silent: true,
+    telegramChatId: '123',
+    telegramChatType: 'private',
+    sourceMessageId: 10,
+    uiLocale: 'en',
+    partialResultText,
+    save: async () => {
+      throw new Error('persisted jobs should update atomically')
+    },
+  })
+
+  const results = await Promise.all([
+    publishTranscriptionJobProgress(makeJob('first partial'), 'partial'),
+    publishTranscriptionJobProgress(makeJob('second partial'), 'partial'),
+  ])
+
+  assert.deepEqual(results.sort(), [false, true])
+  assert.equal(sendCalls.length, 1)
+  assert.equal(sendCalls[0][1], 'first partial')
+  assert.equal(updateCalls.length, 3)
+  assert.equal(updateCalls[0][0], 'findOneAndUpdate')
+  assert.equal(updateCalls[1][0], 'findOneAndUpdate')
+  assert.equal(updateCalls[2][0], 'updateOne')
+  assert.deepEqual(updateCalls[2][2].$set.statusMessageId, 901)
+}
+
 async function provesSilentCompletionSuppressesEmptyFallback() {
   const botPath = require.resolve('../dist/helpers/bot')
   const voicePath = require.resolve('../dist/models/Voice')
@@ -380,6 +447,7 @@ async function provesSilentCompletionPrefersPartsWhenRawTextHasTimecodes() {
 async function main() {
   await provesSilentProgressStartsWithTranscriptText()
   await provesSilentProgressEditsOneTimecodeFreeMessage()
+  await provesSilentProgressClaimsFirstMessageAtomically()
   await provesSilentCompletionSuppressesEmptyFallback()
   await provesSilentCompletionSendsFinalTranscript()
   await provesSilentCompletionOmitsTimecodes()

--- a/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
+++ b/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
@@ -4,7 +4,11 @@ import {
   classifyTelegramReachabilityFailure,
   markChatUnreachableByIdForTelegramError,
 } from '@/helpers/chatReachability'
-import { TranscriptionJob } from '@/models/TranscriptionJob'
+import {
+  TranscriptionJob,
+  TranscriptionJobModel,
+} from '@/models/TranscriptionJob'
+import { Types } from 'mongoose'
 import {
   liveProgressAllowedForChatType,
   shouldThrottleProgressPublish,
@@ -18,6 +22,8 @@ import {
 import bot from '@/helpers/bot'
 
 type ProgressPhase = 'processing' | 'partial' | 'retrying' | 'failed'
+
+const SILENT_STATUS_MESSAGE_PUBLISHING_LEASE_MS = 30_000
 
 function statusTextHtml(
   phase: ProgressPhase,
@@ -36,6 +42,92 @@ function statusTextHtml(
   return partialText
     ? transcriptionProgressPreviewHtml(job.uiLocale, partialText)
     : transcriptionProgressStatusHtml(job.uiLocale, 'progress_partial')
+}
+
+function persistedJobId(job: DocumentType<TranscriptionJob>) {
+  const id = (job as { _id?: unknown })._id
+  return id instanceof Types.ObjectId || typeof id === 'string' ? id : undefined
+}
+
+async function claimSilentStatusMessagePublish(
+  job: DocumentType<TranscriptionJob>
+) {
+  const id = persistedJobId(job)
+  if (!id || job.statusMessageId) {
+    return true
+  }
+
+  const now = new Date()
+  const staleBefore = new Date(
+    now.getTime() - SILENT_STATUS_MESSAGE_PUBLISHING_LEASE_MS
+  )
+  const claimedJob = await TranscriptionJobModel.findOneAndUpdate(
+    {
+      _id: id,
+      silent: true,
+      $and: [
+        {
+          $or: [
+            { statusMessageId: { $exists: false } },
+            { statusMessageId: null },
+          ],
+        },
+        {
+          $or: [
+            { statusMessagePublishingAt: { $exists: false } },
+            { statusMessagePublishingAt: null },
+            { statusMessagePublishingAt: { $lt: staleBefore } },
+          ],
+        },
+      ],
+    },
+    { $set: { statusMessagePublishingAt: now } },
+    { new: true }
+  )
+
+  return Boolean(claimedJob)
+}
+
+async function persistSilentStatusMessage(
+  job: DocumentType<TranscriptionJob>,
+  statusMessageId: number
+) {
+  const now = new Date()
+  job.statusMessageId = statusMessageId
+  job.lastProgressPublishedAt = now
+  job.statusMessagePublishingAt = undefined
+
+  const id = persistedJobId(job)
+  if (!id) {
+    await job.save()
+    return
+  }
+
+  await TranscriptionJobModel.updateOne(
+    { _id: id },
+    {
+      $set: { statusMessageId, lastProgressPublishedAt: now },
+      $unset: { statusMessagePublishingAt: '' },
+    }
+  )
+}
+
+async function releaseSilentStatusMessagePublish(
+  job: DocumentType<TranscriptionJob>
+) {
+  const id = persistedJobId(job)
+  if (!id || job.statusMessageId) {
+    return
+  }
+
+  job.statusMessagePublishingAt = undefined
+  await TranscriptionJobModel.updateOne(
+    {
+      _id: id,
+      $or: [{ statusMessageId: { $exists: false } }, { statusMessageId: null }],
+    },
+    { $unset: { statusMessagePublishingAt: '' } }
+  )
 }
 
 export default async function publishTranscriptionJobProgress(
@@ -66,6 +158,14 @@ export default async function publishTranscriptionJobProgress(
       return false
     }
 
+    const claimedStatusMessagePublish = await claimSilentStatusMessagePublish(
+      job
+    )
+    if (!claimedStatusMessagePublish) {
+      return false
+    }
+
+    let persistedStatusMessage = false
     try {
       if (job.statusMessageId) {
         await bot.api.editMessageText(
@@ -79,9 +179,11 @@ export default async function publishTranscriptionJobProgress(
           parse_mode: 'HTML',
           reply_to_message_id: job.sourceMessageId,
         })
-        job.statusMessageId = message.message_id
+        await persistSilentStatusMessage(job, message.message_id)
+        persistedStatusMessage = true
       }
     } catch (error) {
+      await releaseSilentStatusMessagePublish(job)
       const description =
         error && typeof error === 'object' && 'description' in error
           ? String((error as { description?: string }).description)
@@ -91,8 +193,10 @@ export default async function publishTranscriptionJobProgress(
       }
     }
 
-    job.lastProgressPublishedAt = new Date()
-    await job.save()
+    if (job.statusMessageId && !persistedStatusMessage) {
+      job.lastProgressPublishedAt = new Date()
+      await job.save()
+    }
     return true
   }
 

--- a/src/models/TranscriptionJob.ts
+++ b/src/models/TranscriptionJob.ts
@@ -64,6 +64,8 @@ export class TranscriptionJob {
   @prop()
   statusMessageId?: number
   @prop()
+  statusMessagePublishingAt?: Date
+  @prop()
   silent?: boolean
   @prop()
   requestMessageId?: number


### PR DESCRIPTION
Fixes a production race where concurrent /silent partial-progress callbacks can each observe no statusMessageId and send separate reply bubbles for the same source voice.\n\nChanges:\n- Adds a short DB-backed publish lease for the first silent transcript message.\n- Persists the first statusMessageId atomically after sendMessage.\n- Adds a regression proof that concurrent silent progress publishes result in exactly one sendMessage.\n\nLocal gates:\n- yarn build-ts\n- yarn lint\n- yarn test:silent-mode\n- yarn test:transcription-finalization\n- yarn test:progress-policy\n- yarn test:telegram-api-retry\n- yarn test:chat-reachability