### PR TITLE
Normalize silent transcript line breaks

### DIFF
--- a/scripts/error-empty-handling-proof.js
+++ b/scripts/error-empty-handling-proof.js
@@ -58,6 +58,19 @@ assert.equal(
   'structured worker JSON should prefer timecoded parts when present'
 )
 assert.equal(
+  transcriptText(
+    {
+      resultParts: [
+        { timeCode: '00:01', text: 'first line\ncontinues' },
+        { timeCode: '00:03', text: 'second line' },
+      ],
+    },
+    { includeTimecodes: false }
+  ),
+  'first line continues second line',
+  'plain transcript rendering should remove worker segment line breaks'
+)
+assert.equal(
   localizedTranscriptionText('en', 'completed_empty'),
   'Done, but no text was detected.',
   'English empty-result copy should clearly describe no detected text'

--- a/scripts/silent-mode-proof.js
+++ b/scripts/silent-mode-proof.js
@@ -148,7 +148,7 @@ async function provesSilentProgressEditsOneTimecodeFreeMessage() {
   assert.deepEqual(editCalls[0], [
     '123',
     777,
-    'First transcript chunk.\nSecond transcript chunk.\nThird transcript chunk.',
+    'First transcript chunk. Second transcript chunk. Third transcript chunk.',
     { parse_mode: 'HTML' },
   ])
   assert.equal(saveCount, 2)
@@ -377,7 +377,7 @@ async function provesSilentCompletionOmitsTimecodes() {
   assert.deepEqual(editCalls[0], [
     '123',
     777,
-    'Final first chunk.\nFinal second chunk.',
+    'Final first chunk. Final second chunk.',
   ])
   assert(!editCalls[0][2].includes('00:00:'))
   assert(!editCalls[0][2].includes('00:02:'))
@@ -434,7 +434,7 @@ async function provesSilentCompletionPrefersPartsWhenRawTextHasTimecodes() {
   })
 
   assert.equal(editCalls.length, 1)
-  assert.equal(editCalls[0][2], 'Raw first chunk.\nRaw second chunk.')
+  assert.equal(editCalls[0][2], 'Raw first chunk. Raw second chunk.')
   assert(!editCalls[0][2].includes('00:00:'))
   assert(!editCalls[0][2].includes('00:02:'))
   assert.equal(voiceUpserts.length, 1)

--- a/src/helpers/transcriptionJobs/transcriptFormatting.ts
+++ b/src/helpers/transcriptionJobs/transcriptFormatting.ts
@@ -24,21 +24,30 @@ export function splitTelegramText(text: string) {
   return text.match(new RegExp(`[\\s\\S]{1,${TELEGRAM_MESSAGE_LIMIT}}`, 'g'))
 }
 
+function plainTranscriptText(text: string) {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
 export function transcriptTextFromParts(
   parts?: TranscriptionResultPart[],
   fallback = '',
   { includeTimecodes = true }: TranscriptTextOptions = {}
 ) {
   if (parts?.length) {
+    if (!includeTimecodes) {
+      return parts
+        .map((part) => plainTranscriptText(part.text))
+        .filter(Boolean)
+        .join(' ')
+    }
+
     return parts
       .map((part) =>
-        includeTimecodes && part.timeCode
-          ? `${part.timeCode}:\n${part.text}`
-          : part.text
+        part.timeCode ? `${part.timeCode}:\n${part.text}` : part.text
       )
       .join('\n')
   }
-  return fallback
+  return includeTimecodes ? fallback : plainTranscriptText(fallback)
 }
 
 function parseStructuredTranscriptResult(
@@ -92,7 +101,12 @@ export function transcriptText(
     if (partsText) {
       return partsText
     }
-    return typeof structured.text === 'string' ? structured.text.trim() : ''
+    if (typeof structured.text !== 'string') {
+      return ''
+    }
+    return options.includeTimecodes === false
+      ? plainTranscriptText(structured.text)
+      : structured.text.trim()
   }
 
   const partsText = transcriptTextFromParts(job.resultParts, '', options)
@@ -100,7 +114,13 @@ export function transcriptText(
     return partsText
   }
 
-  return job.resultText?.trim() || partsText || ''
+  if (!job.resultText) {
+    return partsText || ''
+  }
+
+  return options.includeTimecodes === false
+    ? plainTranscriptText(job.resultText)
+    : job.resultText.trim() || partsText || ''
 }
 
 export function partialTranscriptText(


### PR DESCRIPTION
Fixes /silent transcript rendering after the publish-race fix: worker result parts were still joined with hard line breaks when timecodes were hidden.

Changes:
- Collapses plain transcript segment whitespace when includeTimecodes is false.
- Joins silent partial/final transcript parts with spaces instead of newline-separated worker segments.
- Keeps timecoded stored/history text unchanged.
- Adds regression coverage for plain transcript line-break cleanup.

Local gates:
- yarn build-ts
- yarn lint
- yarn test:silent-mode
- yarn test:error-empty-handling
- yarn test:transcription-finalization