### PR TITLE
Localize Voicy transcription status copy

### DIFF
--- a/scripts/error-empty-handling-proof.js
+++ b/scripts/error-empty-handling-proof.js
@@ -80,6 +80,31 @@ assert.equal(
   'Готово, но текст не найден.',
   'Russian empty-result copy should clearly describe no detected text'
 )
+assert.equal(
+  localizedTranscriptionText('de', 'completed_empty'),
+  'Fertig, aber es wurde kein Text erkannt.',
+  'German empty-result copy should clearly describe no detected text'
+)
+assert.equal(
+  localizedTranscriptionText('es', 'completed_empty'),
+  'Listo, pero no se detectó texto.',
+  'Spanish empty-result copy should clearly describe no detected text'
+)
+assert.equal(
+  localizedTranscriptionText('pt', 'completed_empty'),
+  'Concluído, mas nenhum texto foi detectado.',
+  'Portuguese empty-result copy should clearly describe no detected text'
+)
+assert.equal(
+  localizedTranscriptionText('uk', 'completed_empty'),
+  'Готово, але текст не виявлено.',
+  'Ukrainian empty-result copy should clearly describe no detected text'
+)
+assert.equal(
+  localizedTranscriptionText('fr', 'completed_empty'),
+  'Done, but no text was detected.',
+  'unsupported empty-result locale should fall back to English'
+)
 
 const sensitive = [
   '123456789:abcdefghijklmnopqrstuvwxyzABCDE',

--- a/scripts/progress-status-format-proof.js
+++ b/scripts/progress-status-format-proof.js
@@ -39,6 +39,31 @@ assert.equal(
   '<i>✨ Превращаем в текст...</i>',
   'Russian processing status should italicize the full emoji-prefixed line'
 )
+assert.equal(
+  transcriptionProgressStatusHtml('de', 'progress_processing', () => 0.5),
+  '<i>🎧 Wird in Text umgewandelt...</i>',
+  'German processing status should use localized status copy'
+)
+assert.equal(
+  transcriptionProgressStatusHtml('es', 'progress_retrying', () => 0.75),
+  '<i>📝 No se pudo convertir eso en texto; intentándolo de nuevo...</i>',
+  'Spanish retrying status should use localized status copy'
+)
+assert.equal(
+  transcriptionProgressStatusHtml('pt', 'progress_failed', () => 0.999),
+  '<i>🔮 Não foi possível transformar isso em texto. Tente novamente mais tarde.</i>',
+  'Portuguese failure status should use localized status copy'
+)
+assert.equal(
+  transcriptionProgressStatusHtml('uk', 'progress_partial', () => 0),
+  '<i>🪄 Перетворюємо на текст...</i>',
+  'Ukrainian partial status should use localized status copy'
+)
+assert.equal(
+  transcriptionProgressStatusHtml('fr', 'progress_processing', () => 0),
+  '<i>🪄 Turning into text...</i>',
+  'unsupported status locale should fall back to English'
+)
 
 const preview = transcriptionProgressPreviewHtml(
   'en',
@@ -56,6 +81,22 @@ assert(
 assert(
   preview.endsWith('\n\nDraft text; final text may still change.'),
   'partial preview should keep the localized footer outside the italic line'
+)
+
+const localizedPreview = transcriptionProgressPreviewHtml(
+  'es',
+  'borrador',
+  () => 0
+)
+assert(
+  localizedPreview.startsWith('<i>🪄 Convirtiendo en texto...</i>\n\n'),
+  'partial preview should localize the status line'
+)
+assert(
+  localizedPreview.endsWith(
+    '\n\nTexto preliminar; el texto final todavía puede cambiar.'
+  ),
+  'partial preview should localize the footer'
 )
 
 const publishProgressSource = fs.readFileSync(

--- a/src/helpers/localizedTranscriptionText.ts
+++ b/src/helpers/localizedTranscriptionText.ts
@@ -1,7 +1,12 @@
+import { uiLanguages } from '@/helpers/language/uiLanguages'
 import i18n from '@/helpers/i18n'
 
+const supportedLocaleCodes = new Set(
+  uiLanguages.map((language) => language.code)
+)
+
 function supportedLocale(locale?: string) {
-  return locale === 'ru' ? 'ru' : 'en'
+  return locale && supportedLocaleCodes.has(locale) ? locale : 'en'
 }
 
 export default function localizedTranscriptionText(


### PR DESCRIPTION
## Summary
- use the configured Voicy UI language list when resolving transcription status/fallback copy
- keep English fallback for unsupported locale codes
- expand status and empty-transcript proofs across all supported UI languages

## Validation
- yarn build-ts
- yarn lint
- yarn audit-locales
- yarn audit:commands
- yarn test:telegram-markdown
- yarn test:progress-status-format
- yarn test:error-empty-handling
- GitHub check: compile-code passed

## Manual QA
- Chrome CDP URL: http://127.0.0.1:9222
- Target: @okamikron_bot
- Runtime: local branch against isolated Mongo database voicy_kaneo_55
- QA chat set to Spanish in isolated Mongo; Telegram Web visibly showed localized status/draft copy: "Convirtiendo en texto..." and "Texto preliminar; el texto final todavía puede cambiar."
- Screenshot evidence: tmp/voi-kaneo-55-localized-status.png