### PR TITLE
Fix Voicy draft transcript formatting

### DIFF
--- a/scripts/progress-status-format-proof.js
+++ b/scripts/progress-status-format-proof.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+require('reflect-metadata')
 require('module-alias/register')
 
 const assert = require('assert')
@@ -12,6 +13,19 @@ const {
   transcriptionProgressPreviewHtml,
   transcriptionProgressStatusHtml,
 } = require('../dist/helpers/transcriptionJobs/progressStatusText')
+
+function mockModule(path, exports) {
+  require.cache[path] = {
+    id: path,
+    filename: path,
+    loaded: true,
+    exports,
+  }
+}
+
+function clearModule(path) {
+  delete require.cache[path]
+}
 
 assert.equal(
   pickTranscriptionProgressEmoji(() => 0),
@@ -58,6 +72,59 @@ assert(
   'partial preview should keep the localized footer outside the italic line'
 )
 
+async function provesNonSilentDraftProgressHidesWorkerTimecodes() {
+  const botPath = require.resolve('../dist/helpers/bot')
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishTranscriptionJobProgress'
+  )
+  const editCalls = []
+
+  clearModule(publisherPath)
+  mockModule(botPath, {
+    __esModule: true,
+    default: {
+      api: {
+        editMessageText: async (...args) => {
+          editCalls.push(args)
+        },
+      },
+    },
+  })
+
+  const publishTranscriptionJobProgress = require(publisherPath).default
+  const job = {
+    silent: false,
+    chatId: 'chat-1',
+    telegramChatId: '123',
+    telegramChatType: 'private',
+    statusMessageId: 456,
+    uiLocale: 'en',
+    partialResultParts: [
+      { timeCode: '00:00', text: 'Hello from the first segment.' },
+      { timeCode: '00:06', text: 'This should continue naturally.' },
+    ],
+    save: async () => {},
+  }
+
+  assert.equal(await publishTranscriptionJobProgress(job, 'partial'), true)
+  assert.equal(editCalls.length, 1)
+  assert.equal(editCalls[0][0], '123')
+  assert.equal(editCalls[0][1], 456)
+  assert.deepEqual(editCalls[0][3], { parse_mode: 'HTML' })
+  assert(!editCalls[0][2].includes('00:00'))
+  assert(!editCalls[0][2].includes('00:06'))
+  assert(
+    editCalls[0][2].includes(
+      'Hello from the first segment. This should continue naturally.'
+    ),
+    'non-silent draft preview should join worker segment text with spaces'
+  )
+  assert(
+    !editCalls[0][2].includes('Hello from the first segment.\n00:06'),
+    'non-silent draft preview should not preserve artificial segment breaks'
+  )
+}
+
 const publishProgressSource = fs.readFileSync(
   path.join(
     __dirname,
@@ -85,4 +152,11 @@ assert(
   'queued/progress status paths should not edit original media captions'
 )
 
-console.log('progress status format proof passed')
+provesNonSilentDraftProgressHidesWorkerTimecodes()
+  .then(() => {
+    console.log('progress status format proof passed')
+  })
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
+++ b/src/helpers/transcriptionJobs/publishTranscriptionJobProgress.ts
@@ -38,7 +38,7 @@ function statusTextHtml(
   if (phase === 'failed') {
     return transcriptionProgressStatusHtml(job.uiLocale, 'progress_failed')
   }
-  const partialText = partialTranscriptText(job)
+  const partialText = partialTranscriptText(job, { includeTimecodes: false })
   return partialText
     ? transcriptionProgressPreviewHtml(job.uiLocale, partialText)
     : transcriptionProgressStatusHtml(job.uiLocale, 'progress_partial')


### PR DESCRIPTION
## Summary
- hide worker timecodes in non-silent draft/progress transcript previews
- reuse the existing timecode-free transcript normalization so worker segment breaks are joined with spaces
- add a publisher-level regression proof for partial result parts containing timecodes

## Validation
- yarn build-ts
- yarn test:progress-status-format
- yarn test:silent-mode
- yarn lint

## Manual QA
- Telegram Web in Chrome via Codex Computer Use against @okamikron_bot / chat 1737134631.
- Created bot status message 320, then edited it through this branch's publishTranscriptionJobProgress with partial parts containing 00:00 and 00:06.
- Visible result: header/footer remained, body rendered as 'VOI KANEO fifty four draft chunk one. Draft chunk two continues naturally.', and no 00:00/00:06 timestamps were visible.
- Evidence files in workspace: tmp/telegram-voi-54-branch-edit.json and tmp/telegram-voi-54-computer-use.png.
