### PR TITLE
Fix Stripe checkout tax behavior

### DIFF
--- a/scripts/donation-wall-proof.js
+++ b/scripts/donation-wall-proof.js
@@ -319,6 +319,10 @@ async function main() {
         'fixed tier checkout should use the selected amount'
       )
       assert(
+        createdSession.line_items[0].price_data.tax_behavior === 'inclusive',
+        'fixed tier checkout should set tax behavior for automatic tax'
+      )
+      assert(
         createdSession.metadata.voicy_donation_amount === `${amount}`,
         'fixed tier checkout should include amount metadata'
       )

--- a/scripts/stripe-webhook-proof.js
+++ b/scripts/stripe-webhook-proof.js
@@ -13,9 +13,11 @@ const {
   VOICY_STRIPE_FIXED_AMOUNTS,
   VOICY_STRIPE_METADATA_PURPOSE,
   VOICY_STRIPE_MINIMUM_AMOUNT,
+  VOICY_STRIPE_TAX_BEHAVIOR,
   checkoutSessionActivationErrors,
   parseStripeDonationAmount,
   requireStripeWebhookSigningSecret,
+  stripeCheckoutSessionRequest,
   stripeCheckoutMetadata,
   stripeDonationOption,
 } = require('../dist/helpers/stripeCheckoutActivation')
@@ -80,6 +82,15 @@ assertValid()
 
 for (const amount of VOICY_STRIPE_FIXED_AMOUNTS) {
   assertValid(validSession(amount), validLineItems(amount))
+  const request = stripeCheckoutSessionRequest(
+    '-1001234567890',
+    stripeDonationOption(amount)
+  )
+  assert(
+    request.line_items[0].price_data.tax_behavior ===
+      VOICY_STRIPE_TAX_BEHAVIOR,
+    'checkout price data should include tax behavior for automatic tax'
+  )
 }
 assertValid(
   validSession(VOICY_STRIPE_MINIMUM_AMOUNT + 432),

--- a/src/helpers/stripeCheckoutActivation.ts
+++ b/src/helpers/stripeCheckoutActivation.ts
@@ -25,6 +25,8 @@ export const VOICY_STRIPE_METADATA_PURPOSE = 'voicy_chat_activation'
 export const VOICY_STRIPE_CUSTOM_TIER = 'custom'
 export const VOICY_STRIPE_PRODUCT_NAME =
   process.env.STRIPE_PRODUCT_NAME || 'Voicy chat transcription activation'
+export const VOICY_STRIPE_TAX_BEHAVIOR =
+  process.env.STRIPE_TAX_BEHAVIOR === 'exclusive' ? 'exclusive' : 'inclusive'
 
 export type StripeDonationTier = 'fixed' | 'custom'
 
@@ -210,6 +212,7 @@ export function stripeCheckoutSessionRequest(
           product_data: {
             name: VOICY_STRIPE_PRODUCT_NAME,
           },
+          tax_behavior: VOICY_STRIPE_TAX_BEHAVIOR,
           unit_amount: donation.amount,
         },
         quantity: 1,


### PR DESCRIPTION
## Summary
- set tax_behavior on inline Stripe Checkout price data so automatic tax can create donation sessions
- default to inclusive tax behavior to match the existing live Voicy $6.99 Stripe price, with STRIPE_TAX_BEHAVIOR=exclusive as an override
- add proof coverage for fixed donation tiers and checkout request generation

## Validation
- yarn build-ts
- yarn lint
- yarn test:stripe-webhook
- yarn test:donation-wall
- live Stripe API check: all configured tiers can create Checkout Sessions when tax_behavior is included