### PR TITLE
Fix donation wall access guidance

### DIFF
--- a/scripts/donation-wall-proof.js
+++ b/scripts/donation-wall-proof.js
@@ -141,8 +141,12 @@ async function withPatchedQueue(callback, accessResult) {
     return jobDoc
   }
   abuseLimits.checkTranscriptionAbuseLimits = async () => undefined
-  goldenBorodutchAllowance.checkTranscriptionAccess = async () =>
-    accessResult || { allowed: true, consumedFreeTranscription: false }
+  goldenBorodutchAllowance.checkTranscriptionAccess = async () => {
+    if (accessResult instanceof Error) {
+      throw accessResult
+    }
+    return accessResult || { allowed: true, consumedFreeTranscription: false }
+  }
 
   try {
     await callback(createdJobs)
@@ -290,6 +294,28 @@ async function main() {
       consumedFreeTranscription: false,
       reason: 'subscription_required',
     }
+  )
+
+  await withPatchedQueue(
+    async (createdJobs) => {
+      process.env.VOICY_DONATION_WALL_ENABLED = 'true'
+      const ctx = mockContext({ paid: false, chatType: 'private' })
+      await handleAudio(ctx)
+
+      assert(
+        createdJobs.length === 0,
+        'access-check failure should not enqueue audio'
+      )
+      assert(
+        ctx.replies.length === 1,
+        'access-check failure should still explain donation/subscription access'
+      )
+      assert(
+        ctx.replies[0].text === 'golden_borodutch_membership_check_failed',
+        'access-check failure should not fall through to generic queue error'
+      )
+    },
+    new Error('database unavailable while recording membership check')
   )
 
   await withPatchedStripeCheckout(async (createdSessions) => {

--- a/scripts/golden-borodutch-allowance-proof.js
+++ b/scripts/golden-borodutch-allowance-proof.js
@@ -191,6 +191,26 @@ async function main() {
   )
   assert.equal(errorStore.records.get('101').transcriptionsUsed, 0)
 
+  const expectedNonMemberErrorApi = telegramApi([
+    new Error('Bad Request: user not found'),
+  ])
+  const expectedNonMemberErrorStore = memoryStore()
+  const expectedNonMemberErrorResult = await check({
+    chat: { paid: false },
+    userId: '101',
+    api: expectedNonMemberErrorApi,
+    store: expectedNonMemberErrorStore,
+  })
+  assert.equal(expectedNonMemberErrorResult.allowed, false)
+  assert.equal(
+    expectedNonMemberErrorResult.reason,
+    TranscriptionAccessDenialReason.subscriptionRequired
+  )
+  assert.equal(
+    expectedNonMemberErrorStore.records.get('101').transcriptionsUsed,
+    0
+  )
+
   const missingUserResult = await check({
     chat: { paid: false },
     api: telegramApi([]),

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -104,11 +104,24 @@ async function enqueueTranscription(
   }
 
   const freeAccessUserId = transcriptionAccessUserId(sourceMessage, ctx)
-  const access = await checkTranscriptionAccess({
-    chat: ctx.dbchat,
-    telegramUserId: freeAccessUserId,
-    telegramApi: ctx.api,
-  })
+  let access
+  try {
+    access = await checkTranscriptionAccess({
+      chat: ctx.dbchat,
+      telegramUserId: freeAccessUserId,
+      telegramApi: ctx.api,
+    })
+  } catch (error) {
+    report(error, { ctx, location: 'checkTranscriptionAccess' })
+    if (!ctx.dbchat.silent) {
+      await sendTranscriptionAccessError(
+        ctx,
+        TranscriptionAccessDenialReason.membershipCheckFailed,
+        sourceMessage
+      )
+    }
+    return undefined
+  }
   if (!access.allowed) {
     if (!ctx.dbchat.silent) {
       await sendTranscriptionAccessError(ctx, access.reason, sourceMessage)

--- a/src/helpers/goldenBorodutchFreeTranscriptions.ts
+++ b/src/helpers/goldenBorodutchFreeTranscriptions.ts
@@ -109,9 +109,10 @@ export async function checkTranscriptionAccess({
     return {
       allowed: false,
       consumedFreeTranscription: false,
-      reason: membership.error
-        ? TranscriptionAccessDenialReason.membershipCheckFailed
-        : TranscriptionAccessDenialReason.subscriptionRequired,
+      reason:
+        membership.error && !isExpectedNonMemberError(membership.error)
+          ? TranscriptionAccessDenialReason.membershipCheckFailed
+          : TranscriptionAccessDenialReason.subscriptionRequired,
     }
   }
 
@@ -182,6 +183,16 @@ function isActiveTelegramMember(member: {
     ['creator', 'administrator', 'member'].includes(member.status) ||
     (member.status === 'restricted' && member.is_member === true)
   )
+}
+
+function isExpectedNonMemberError(error: string) {
+  const normalized = error.toLowerCase()
+  return [
+    'user not found',
+    'participant_id_invalid',
+    'user_not_participant',
+    'chat member not found',
+  ].some((expectedError) => normalized.includes(expectedError))
 }
 
 const mongoFreeTranscriptionStore: FreeTranscriptionStore = {


### PR DESCRIPTION
## Summary
- treat expected Telegram non-member responses as subscription-required instead of membership-check failures
- keep donation-wall access failures from falling through to the generic queue error
- add proof coverage for non-member errors and access-check exceptions

## Validation
- yarn build-ts
- yarn lint
- yarn test:donation-wall
- yarn test:golden-borodutch-allowance
- yarn test:telegram-markdown