### PR TITLE
Log Windows Voicy worker transcription activity

### DIFF
--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -226,6 +226,28 @@ backticks, and parentheses in paths and prevents shell expansion.
 `scripts/whisper-transcriber.js` reads `VOICY_WORKER_MODEL` directly, so it does
 not need `{model}` in the args array.
 
+The worker logs transcription activity without transcript text, tokens, or
+source URLs. For each job, the Windows service log includes command start,
+command completion, result upload, and final completion lines with `jobId`,
+`chatId`, `telegramChatId`, `sourceKind`, file size, requested/detected
+language, attempt count, local input/output file names, elapsed command time,
+text character count, empty-result status, part count, and optional audio
+duration. Use these lines to confirm that the Windows host is actively
+transcribing and uploading results while keeping media URLs, worker tokens, raw
+audio, and transcript text out of logs.
+
+For persistent Windows Task Scheduler logs, run `yarn worker:run` from a
+PowerShell wrapper that redirects standard output and error to a local file the
+worker account can write, for example:
+
+```powershell
+$log = "C:\voicy-worker\logs\worker-$(Get-Date -Format yyyyMMdd).log"
+yarn worker:run *>> $log
+```
+
+Rotate or prune `C:\voicy-worker\logs` with the same operational policy as the
+worker job directory.
+
 The checked-in worker client uploads the final result after the command exits.
 Streaming-capable custom workers may call `POST /jobs/:id/progress` while a
 transcription command emits stable segments, then must still call

--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -78,7 +78,14 @@ function createProofServer() {
           job: {
             id: 'proof-job',
             status: 'processing',
+            chatId: 'proof-chat',
+            telegramChatId: '12345',
+            telegramChatType: 'private',
+            sourceMessageId: 101,
             sourceKind: 'voice',
+            sourceUrl:
+              'https://api.telegram.org/file/botproof-telegram-token/audio/proof.ogg',
+            fileSize: 17,
             recognitionLanguageHint: 'en',
             attempts: 1,
           },
@@ -103,7 +110,14 @@ function createProofServer() {
           job: {
             id: 'proof-job',
             status: 'downloading',
+            chatId: 'proof-chat',
+            telegramChatId: '12345',
+            telegramChatType: 'private',
+            sourceMessageId: 101,
             sourceKind: 'voice',
+            sourceUrl:
+              'https://api.telegram.org/file/botproof-telegram-token/audio/proof.ogg',
+            fileSize: 17,
             recognitionLanguageHint: 'en',
             attempts: 1,
           },
@@ -164,7 +178,12 @@ function createProofServer() {
           job: {
             id: 'proof-job',
             status: 'ready',
+            chatId: 'proof-chat',
+            telegramChatId: '12345',
+            telegramChatType: 'private',
+            sourceMessageId: 101,
             sourceKind: 'voice',
+            fileSize: 17,
             recognitionLanguageHint: 'en',
             attempts: 1,
           },
@@ -184,7 +203,12 @@ function createProofServer() {
           job: {
             id: 'proof-job',
             status: 'transcribing',
+            chatId: 'proof-chat',
+            telegramChatId: '12345',
+            telegramChatType: 'private',
+            sourceMessageId: 101,
             sourceKind: 'voice',
+            fileSize: 17,
             recognitionLanguageHint: 'en',
             attempts: 1,
           },
@@ -436,13 +460,90 @@ async function main() {
       VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
     }
     const config = loadConfig(env)
+    const logLines = []
     const processed = await processNextJob(config, {
-      info: () => undefined,
-      warn: () => undefined,
-      error: () => undefined,
+      info: (message) => logLines.push(message),
+      warn: (message) => logLines.push(message),
+      error: (message) => logLines.push(message),
     })
 
     assert(processed, 'worker should process the claimed job')
+    assert(
+      logLines.every(
+        (line) =>
+          !line.includes('proof-telegram-token') &&
+          !line.includes('api.telegram.org/file') &&
+          !line.includes('fake transcript from worker client proof')
+      ),
+      'worker activity logs should not include tokens, source URLs, or transcript text'
+    )
+    assert(
+      logLines.some(
+        (line) =>
+          line.includes('Worker media download job claimed') &&
+          line.includes('jobId="proof-job"') &&
+          line.includes('chatId="proof-chat"') &&
+          line.includes('telegramChatId="12345"') &&
+          line.includes('sourceMessageId=101') &&
+          line.includes('sourceKind="voice"') &&
+          line.includes('fileSize=17')
+      ),
+      'worker should log media claim context'
+    )
+    assert(
+      logLines.some(
+        (line) =>
+          line.includes('Worker transcription job started') &&
+          line.includes('jobId="proof-job"') &&
+          line.includes('engine="proof-engine"') &&
+          line.includes('model="proof-model"') &&
+          line.includes('sourceKind="voice"') &&
+          line.includes('fileSize=17')
+      ),
+      'worker should log transcription job start context'
+    )
+    assert(
+      logLines.some(
+        (line) =>
+          line.includes('Worker transcription command starting') &&
+          line.includes('jobId="proof-job"') &&
+          line.includes('engine="proof-engine"') &&
+          line.includes('model="proof-model"') &&
+          line.includes('language="en"')
+      ),
+      'worker should log transcription command start context'
+    )
+    assert(
+      logLines.some(
+        (line) =>
+          line.includes('Worker transcription command completed') &&
+          line.includes('jobId="proof-job"') &&
+          line.includes('outputSource="file"') &&
+          line.includes('textChars=40') &&
+          line.includes('parts=1')
+      ),
+      'worker should log transcription command completion metrics'
+    )
+    assert(
+      logLines.some(
+        (line) =>
+          line.includes('Worker transcription result uploading') &&
+          line.includes('jobId="proof-job"') &&
+          line.includes('textChars=40') &&
+          line.includes('emptyResult=false')
+      ),
+      'worker should log transcription result upload metrics'
+    )
+    assert(
+      logLines.some(
+        (line) =>
+          line.includes('Worker transcription job completed') &&
+          line.includes('jobId="proof-job"') &&
+          line.includes('textChars=40') &&
+          line.includes('emptyResult=false')
+      ),
+      'worker should log transcription job completion metrics'
+    )
     assert(
       !state.failure,
       `worker should not report failure: ${JSON.stringify(state.failure)}`
@@ -498,7 +599,9 @@ async function main() {
   await listen(emptyProof.server)
 
   try {
-    const baseUrl = `http://127.0.0.1:${emptyProof.server.address().port}/worker/v1`
+    const baseUrl = `http://127.0.0.1:${
+      emptyProof.server.address().port
+    }/worker/v1`
     const config = loadConfig({
       VOICY_WORKER_API_URL: baseUrl,
       VOICY_WORKER_TOKEN: 'proof-worker-token',

--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -655,7 +655,7 @@ async function main() {
       VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
       VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
         '-e',
-        'process.stderr.write("boom"); process.exit(3)',
+        'process.stdout.write("PRIVATE TRANSCRIPT"); process.stderr.write("PRIVATE STDERR"); process.exit(3)',
       ]),
       VOICY_WORKER_WORK_DIR: path.join(
         os.tmpdir(),
@@ -667,10 +667,11 @@ async function main() {
       VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
     })
 
+    const failureLogLines = []
     const processed = await processNextJob(config, {
-      info: () => undefined,
-      warn: () => undefined,
-      error: () => undefined,
+      info: (message) => failureLogLines.push(message),
+      warn: (message) => failureLogLines.push(message),
+      error: (message) => failureLogLines.push(message),
     })
 
     assert(processed, 'worker should process the failure job')
@@ -682,6 +683,24 @@ async function main() {
     assert(
       failureProof.state.failure.retryable === true,
       'command failure should be retryable'
+    )
+    assert(
+      failureProof.state.failure.error.includes('stdoutChars=18') &&
+        failureProof.state.failure.error.includes('stderrChars=14'),
+      'failed command should report output lengths for diagnostics'
+    )
+    assert(
+      !failureProof.state.failure.error.includes('PRIVATE TRANSCRIPT') &&
+        !failureProof.state.failure.error.includes('PRIVATE STDERR'),
+      'failed command should not report raw stdout or stderr'
+    )
+    assert(
+      failureLogLines.every(
+        (line) =>
+          !line.includes('PRIVATE TRANSCRIPT') &&
+          !line.includes('PRIVATE STDERR')
+      ),
+      'failed command logs should not include raw stdout or stderr'
     )
   } finally {
     await close(failureProof.server)

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -20,9 +20,14 @@ const DEFAULT_WORKER_MODEL = 'large-v3'
 interface WorkerJob {
   id: string
   status: string
+  chatId?: string
+  telegramChatId?: string
+  telegramChatType?: string
+  sourceMessageId?: number
   sourceUrl?: string
   sourceKind?: string
   mimeType?: string
+  fileSize?: number
   localSourcePath?: string
   recognitionLanguageHint?: string
   attempts?: number
@@ -88,6 +93,7 @@ interface Logger {
 interface RunCommandResult {
   stdout: string
   stderr: string
+  elapsedMs: number
 }
 
 interface DownloadedJob {
@@ -99,6 +105,45 @@ const consoleLogger: Logger = {
   info: (message) => console.log(message),
   warn: (message) => console.warn(message),
   error: (message) => console.error(message),
+}
+
+type LogValue = string | number | boolean | undefined
+
+function formatLogValue(value: LogValue) {
+  if (typeof value === 'string') {
+    return JSON.stringify(value)
+  }
+  return String(value)
+}
+
+function formatLogContext(context: Record<string, LogValue>) {
+  return Object.entries(context)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}=${formatLogValue(value)}`)
+    .join(' ')
+}
+
+function logWorkerActivity(
+  logger: Logger,
+  message: string,
+  context: Record<string, LogValue>
+) {
+  const formattedContext = formatLogContext(context)
+  logger.info(formattedContext ? `${message} ${formattedContext}` : message)
+}
+
+function jobLogContext(job: WorkerJob): Record<string, LogValue> {
+  return {
+    jobId: job.id,
+    chatId: job.chatId,
+    telegramChatId: job.telegramChatId,
+    telegramChatType: job.telegramChatType,
+    sourceMessageId: job.sourceMessageId,
+    sourceKind: job.sourceKind,
+    fileSize: job.fileSize,
+    language: job.recognitionLanguageHint,
+    attempts: job.attempts,
+  }
 }
 
 class WorkerClientError extends Error {
@@ -459,6 +504,7 @@ function runCommand(
   config: WorkerConfig
 ): Promise<RunCommandResult> {
   return new Promise((resolve, reject) => {
+    const startedAt = Date.now()
     const child = spawn(executable, args, {
       shell: false,
       windowsHide: true,
@@ -484,6 +530,7 @@ function runCommand(
     child.on('close', (code) => {
       const stdout = Buffer.concat(stdoutChunks).toString('utf8')
       const stderr = Buffer.concat(stderrChunks).toString('utf8')
+      const elapsedMs = Date.now() - startedAt
       if (code !== 0) {
         reject(
           new WorkerClientError(
@@ -492,7 +539,7 @@ function runCommand(
         )
         return
       }
-      resolve({ stdout, stderr })
+      resolve({ stdout, stderr, elapsedMs })
     })
   })
 }
@@ -540,24 +587,48 @@ async function readTranscriptionOutput(
   outputPath: string,
   config: WorkerConfig,
   job: WorkerJob,
-  inputPath: string
+  inputPath: string,
+  logger: Logger
 ) {
   const outputStat = await stat(outputPath).catch(() => undefined)
   const rawOutput = outputStat
     ? await readFile(outputPath, 'utf8')
     : commandResult.stdout
-  return normalizeTranscriptionOutput(rawOutput, config, job, inputPath)
+  const result = normalizeTranscriptionOutput(rawOutput, config, job, inputPath)
+  logWorkerActivity(logger, 'Worker transcription command completed', {
+    jobId: job.id,
+    engine: config.engine,
+    model: config.model,
+    language: result.language,
+    elapsedMs: commandResult.elapsedMs,
+    outputSource: outputStat ? 'file' : 'stdout',
+    textChars: result.text.length,
+    parts: result.parts?.length || 0,
+    duration: result.duration,
+  })
+  return result
 }
 
 async function transcribeJob(
   config: WorkerConfig,
   job: WorkerJob,
-  inputPath: string
+  inputPath: string,
+  logger: Logger
 ) {
   const outputPath = path.join(config.workDir, `${job.id}.transcript.json`)
   await removeIfExists(outputPath)
   const language = job.recognitionLanguageHint || config.language
   const args = commandArgsForJob(config, inputPath, outputPath, language)
+  logWorkerActivity(logger, 'Worker transcription command starting', {
+    jobId: job.id,
+    engine: config.engine,
+    model: config.model,
+    language,
+    sourceKind: job.sourceKind,
+    attempts: job.attempts,
+    inputFile: path.basename(inputPath),
+    outputFile: path.basename(outputPath),
+  })
   const commandResult = await runCommand(
     config.transcribeExecutable,
     args,
@@ -568,7 +639,8 @@ async function transcribeJob(
     outputPath,
     config,
     job,
-    inputPath
+    inputPath,
+    logger
   )
 }
 
@@ -619,7 +691,12 @@ async function downloadJob(
   job: WorkerJob,
   logger: Logger
 ): Promise<DownloadedJob | undefined> {
-  logger.info(`Claimed media download job ${job.id}`)
+  const startedAt = Date.now()
+  logWorkerActivity(
+    logger,
+    'Worker media download job claimed',
+    jobLogContext(job)
+  )
   const heartbeat = startHeartbeat(
     api,
     job.id,
@@ -631,9 +708,20 @@ async function downloadJob(
     const source = await getSource(api, job.id)
     const inputPath = await downloadSource(config, job, source)
     const readyJob = await markDownloaded(api, job.id, inputPath)
-    logger.info(`Downloaded media for job ${job.id}`)
+    logWorkerActivity(logger, 'Worker media download completed', {
+      ...jobLogContext(readyJob),
+      elapsedMs: Date.now() - startedAt,
+      inputFile: path.basename(inputPath),
+    })
     return { job: readyJob, inputPath }
   } catch (error) {
+    const retryable =
+      error instanceof WorkerClientError ? error.retryable : true
+    logWorkerActivity(logger, 'Worker media download failed', {
+      ...jobLogContext(job),
+      elapsedMs: Date.now() - startedAt,
+      retryable,
+    })
     await failJob(api, job.id, error, logger)
     return undefined
   } finally {
@@ -649,10 +737,16 @@ async function transcribeDownloadedJob(
   downloaded: DownloadedJob,
   logger: Logger
 ) {
+  const startedAt = Date.now()
   const job = ['processing', 'transcribing'].includes(downloaded.job.status)
     ? downloaded.job
     : await startTranscription(api, downloaded.job.id)
-  logger.info(`Started transcription job ${job.id}`)
+  logWorkerActivity(logger, 'Worker transcription job started', {
+    ...jobLogContext(job),
+    engine: config.engine,
+    model: config.model,
+    inputFile: path.basename(downloaded.inputPath),
+  })
   const heartbeat = startHeartbeat(
     api,
     job.id,
@@ -661,10 +755,43 @@ async function transcribeDownloadedJob(
   )
 
   try {
-    const result = await transcribeJob(config, job, downloaded.inputPath)
+    const result = await transcribeJob(
+      config,
+      job,
+      downloaded.inputPath,
+      logger
+    )
+    logWorkerActivity(logger, 'Worker transcription result uploading', {
+      jobId: job.id,
+      engine: config.engine,
+      model: config.model,
+      language: result.language,
+      elapsedMs: Date.now() - startedAt,
+      textChars: result.text.length,
+      emptyResult: result.text.length === 0,
+      parts: result.parts?.length || 0,
+    })
     await api.post(`/jobs/${job.id}/result`, result)
-    logger.info(`Completed transcription job ${job.id}`)
+    logWorkerActivity(logger, 'Worker transcription job completed', {
+      jobId: job.id,
+      engine: config.engine,
+      model: config.model,
+      language: result.language,
+      elapsedMs: Date.now() - startedAt,
+      textChars: result.text.length,
+      emptyResult: result.text.length === 0,
+      parts: result.parts?.length || 0,
+    })
   } catch (error) {
+    const retryable =
+      error instanceof WorkerClientError ? error.retryable : true
+    logWorkerActivity(logger, 'Worker transcription job failed', {
+      ...jobLogContext(job),
+      engine: config.engine,
+      model: config.model,
+      elapsedMs: Date.now() - startedAt,
+      retryable,
+    })
     await failJob(api, job.id, error, logger)
   } finally {
     if (heartbeat) {
@@ -745,6 +872,11 @@ export async function processAvailableJobs(
     return processed
   }
 
+  logWorkerActivity(
+    logger,
+    'Worker legacy transcription job claimed',
+    jobLogContext(legacyJob)
+  )
   const source = await getSource(api, legacyJob.id)
   const inputPath =
     legacyJob.localSourcePath ||

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -534,7 +534,7 @@ function runCommand(
       if (code !== 0) {
         reject(
           new WorkerClientError(
-            `Transcription command exited with ${code}: ${stderr || stdout}`
+            `Transcription command exited with ${code}; stdoutChars=${stdout.length}; stderrChars=${stderr.length}`
           )
         )
         return


### PR DESCRIPTION
## Summary
- Add readable worker activity logs for media claim/download, transcription start, command completion, result upload, completion, and failure paths.
- Include non-secret job context and metrics such as job/chat IDs, source kind, file size, language, model/engine, elapsed time, result length, empty-result status, and part count.
- Suppress raw transcriber stdout/stderr on command failures while preserving exit code and output-length diagnostics, so failed local STT runs cannot leak transcript text into logs or worker API failure payloads.
- Extend the worker-client proof to assert activity logging does not include Telegram file tokens, source URLs, transcript text, or raw failed-command output; document Task Scheduler log redirection for persistent Windows logs.

## Testing
- yarn build-ts
- yarn test:worker-client
- yarn lint
- git diff --check

## Manual QA
- Required after deploy/update on borodutch-pc: confirm VoicyWorker4070Ti scheduled task logs show claimed/start/completed or failure activity lines for a real transcription and do not include tokens, Telegram file URLs, raw audio, raw transcriber stdout/stderr, or full transcript text.