### PR TITLE
Disable web previews for Voicy start/help messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:donation-wall": "node scripts/donation-wall-proof.js",
     "test:telegram-runtime": "node scripts/telegram-runtime-check.js",
     "test:id-command": "node scripts/id-command-proof.js",
+    "test:start-help-previews": "node scripts/start-help-preview-proof.js",
     "test:local-runtime-health": "node scripts/local-runtime-health.js",
     "test:stripe-webhook": "node scripts/stripe-webhook-proof.js",
     "test:telegram-markdown": "node scripts/telegram-markdown-proof.js",

--- a/scripts/language-selection-proof.js
+++ b/scripts/language-selection-proof.js
@@ -91,7 +91,13 @@ async function provesManualLanguageSurvivesStart() {
 
   assert.equal(ctx.dbchat.uiLanguage, 'ru')
   assert.equal(ctx.i18n.currentLocale, 'ru')
-  assert.deepEqual(calls, [['reply', 'ru:start:', { parse_mode: 'Markdown' }]])
+  assert.deepEqual(calls, [
+    [
+      'reply',
+      'ru:start:',
+      { disable_web_page_preview: true, parse_mode: 'Markdown' },
+    ],
+  ])
 }
 
 async function provesEverySupportedLanguageCanBeSelected() {
@@ -147,7 +153,11 @@ async function provesTelegramLanguageStillInitializesUnselectedChats() {
   assert.equal(ctx.dbchat.uiLanguage, 'ru')
   assert.equal(ctx.dbchat.uiLanguageSelectedManually, false)
   assert.deepEqual(calls[0], ['save', 'ru', false])
-  assert.deepEqual(calls[1], ['reply', 'ru:start:', { parse_mode: 'Markdown' }])
+  assert.deepEqual(calls[1], [
+    'reply',
+    'ru:start:',
+    { disable_web_page_preview: true, parse_mode: 'Markdown' },
+  ])
 }
 
 async function provesLanguageCallbackFallsBackWhenEditFails() {

--- a/scripts/start-help-preview-proof.js
+++ b/scripts/start-help-preview-proof.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+require('reflect-metadata')
+require('module-alias/register')
+
+const assert = require('assert')
+
+const handleHelp = require('../dist/commands/handleHelp').default
+const handleStart = require('../dist/commands/handleStart').default
+
+function createContext() {
+  const calls = []
+  const dbchat = {
+    uiLanguage: 'en',
+    uiLanguageSelectedManually: true,
+    async save() {
+      calls.push(['save'])
+      return this
+    },
+  }
+
+  return {
+    ctx: {
+      timeReceived: new Date(),
+      dbchat,
+      i18n: {
+        locale() {
+          return 'en'
+        },
+        t(key) {
+          return `en:${key}`
+        },
+      },
+      reply: async (text, options) => calls.push(['reply', text, options]),
+      from: { language_code: 'en' },
+      chat: { id: 1 },
+      msg: { message_id: 1 },
+    },
+    calls,
+  }
+}
+
+async function provesStartDisablesWebPreviews() {
+  const { ctx, calls } = createContext()
+
+  await handleStart(ctx)
+
+  assert.deepEqual(calls, [
+    [
+      'reply',
+      'en:start',
+      { disable_web_page_preview: true, parse_mode: 'Markdown' },
+    ],
+  ])
+}
+
+async function provesHelpDisablesWebPreviews() {
+  const { ctx, calls } = createContext()
+
+  await handleHelp(ctx)
+
+  assert.deepEqual(calls, [
+    [
+      'reply',
+      'en:help',
+      { disable_web_page_preview: true, parse_mode: 'Markdown' },
+    ],
+  ])
+}
+
+Promise.resolve()
+  .then(provesStartDisablesWebPreviews)
+  .then(provesHelpDisablesWebPreviews)
+  .then(() => {
+    console.log('start/help preview proof passed')
+  })
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/src/helpers/sendStart.ts
+++ b/src/helpers/sendStart.ts
@@ -5,6 +5,7 @@ import logAnswerTime from '@/helpers/logAnswerTime'
 
 export default async function sendStart(ctx: Context) {
   await ctx.reply(markdownI18n(ctx, 'start'), {
+    disable_web_page_preview: true,
     parse_mode: 'Markdown',
   })
   await markChatReachable(ctx, '/start')


### PR DESCRIPTION
## Summary
- disable Telegram web previews on `/start` replies
- keep `/help` preview suppression covered with a focused proof
- update start/language assertions to expect preview suppression

## Validation
- `yarn build-ts`
- `yarn lint`
- `yarn audit-locales`
- `yarn test:telegram-markdown`
- `yarn audit:commands`
- `yarn test:start-help-previews && yarn test:language-selection`
- `./node_modules/.bin/prettier --check package.json scripts/language-selection-proof.js scripts/start-help-preview-proof.js`

## Manual QA
Required before done: in a controlled Telegram bot/chat, send `/start` and `/help`; verify no website/GitHub preview cards appear and message text/formatting stays unchanged. Symphony did not run live Telegram QA in this pass.