### PR TITLE
Cache Voicy transcription results by Telegram media

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:telegram-markdown": "node scripts/telegram-markdown-proof.js",
     "test:telegram-api-retry": "node scripts/telegram-api-retry-proof.js",
     "test:stale-telegram-updates": "node scripts/stale-telegram-update-proof.js",
+    "test:transcription-cache": "node scripts/transcription-cache-proof.js",
     "qa:telegram-upload": "node scripts/telegram-web-upload-qa.mjs",
     "worker:create-client": "node scripts/create-worker-client.js",
     "security:scrub-source-urls": "node scripts/scrub-token-bearing-source-urls.js",

--- a/scripts/donation-wall-proof.js
+++ b/scripts/donation-wall-proof.js
@@ -21,6 +21,9 @@ const {
   TranscriptionJobModel,
   TranscriptionJobStatus,
 } = require('../dist/models/TranscriptionJob')
+const {
+  TranscriptionResultCacheModel,
+} = require('../dist/models/TranscriptionResultCache')
 const abuseLimits = require('../dist/helpers/transcriptionJobs/abuseLimits')
 const goldenBorodutchAllowance = require('../dist/helpers/goldenBorodutchFreeTranscriptions')
 
@@ -125,6 +128,7 @@ async function withPatchedStripeCheckout(callback) {
 
 async function withPatchedQueue(callback, accessResult) {
   const originalCreate = TranscriptionJobModel.create
+  const originalFindCache = TranscriptionResultCacheModel.findOne
   const originalCheckLimits = abuseLimits.checkTranscriptionAbuseLimits
   const originalCheckAccess = goldenBorodutchAllowance.checkTranscriptionAccess
   const createdJobs = []
@@ -144,6 +148,7 @@ async function withPatchedQueue(callback, accessResult) {
     createdJobs.push(jobDoc)
     return jobDoc
   }
+  TranscriptionResultCacheModel.findOne = async () => undefined
   abuseLimits.checkTranscriptionAbuseLimits = async () => undefined
   goldenBorodutchAllowance.checkTranscriptionAccess = async () => {
     if (accessResult instanceof Error) {
@@ -156,6 +161,7 @@ async function withPatchedQueue(callback, accessResult) {
     await callback(createdJobs)
   } finally {
     TranscriptionJobModel.create = originalCreate
+    TranscriptionResultCacheModel.findOne = originalFindCache
     abuseLimits.checkTranscriptionAbuseLimits = originalCheckLimits
     goldenBorodutchAllowance.checkTranscriptionAccess = originalCheckAccess
   }

--- a/scripts/transcription-cache-proof.js
+++ b/scripts/transcription-cache-proof.js
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+
+process.env.TOKEN = process.env.TOKEN || '123456:proof-token-secret'
+
+require('reflect-metadata')
+require('module-alias/register')
+
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+
+const TRANSCRIPTION_STATUSES = {
+  queuedForDownload: 'queued_for_download',
+  completed: 'completed',
+}
+
+const TRANSCRIPTION_SOURCE_KINDS = {
+  voice: 'voice',
+  videoNote: 'video_note',
+  audio: 'audio',
+  document: 'document',
+  video: 'video',
+}
+
+function mockModule(modulePath, exports) {
+  require.cache[modulePath] = {
+    id: modulePath,
+    filename: modulePath,
+    loaded: true,
+    exports,
+  }
+}
+
+function clearModule(modulePath) {
+  delete require.cache[modulePath]
+}
+
+function clearVoicyModules() {
+  for (const key of Object.keys(require.cache)) {
+    if (key.includes(`${path.sep}dist${path.sep}`)) {
+      delete require.cache[key]
+    }
+  }
+}
+
+function mockContext({
+  chatType = 'private',
+  silent = false,
+  media = {
+    file_id: 'proof-file-id',
+    file_unique_id: 'proof-file-unique-id',
+    file_size: 4096,
+  },
+} = {}) {
+  return {
+    dbchat: {
+      id: 'cache-proof-chat',
+      paid: true,
+      transcribeAllAudio: true,
+      uiLanguage: 'en',
+      silent,
+    },
+    chat: { id: 12345, type: chatType },
+    from: { id: 67890 },
+    msg: {
+      message_id: 111,
+      voice: media,
+    },
+    api: {},
+    reply: async () => {
+      throw new Error('cache proof should not send queue acknowledgements')
+    },
+    timeReceived: new Date(),
+  }
+}
+
+function installHandleAudioMocks({
+  cachedResult,
+  accessResult = { allowed: true, consumedFreeTranscription: true },
+} = {}) {
+  clearVoicyModules()
+
+  const transcriptionJobPath = require.resolve('../dist/models/TranscriptionJob')
+  const cacheModelPath = require.resolve(
+    '../dist/models/TranscriptionResultCache'
+  )
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+  )
+  const abusePath = require.resolve(
+    '../dist/helpers/transcriptionJobs/abuseLimits'
+  )
+  const accessPath = require.resolve(
+    '../dist/helpers/goldenBorodutchFreeTranscriptions'
+  )
+
+  const createdJobs = []
+  const cacheQueries = []
+  const publishedJobs = []
+  const accessCalls = []
+  const refunds = []
+
+  mockModule(transcriptionJobPath, {
+    TranscriptionJobStatus: TRANSCRIPTION_STATUSES,
+    TranscriptionJobSourceKind: TRANSCRIPTION_SOURCE_KINDS,
+    TranscriptionJobModel: {
+      create: async (job) => {
+        const jobDoc = {
+          ...job,
+          save: async () => undefined,
+        }
+        createdJobs.push(jobDoc)
+        return jobDoc
+      },
+    },
+  })
+  mockModule(cacheModelPath, {
+    TranscriptionResultCacheModel: {
+      findOne: async (query) => {
+        cacheQueries.push(query)
+        return cachedResult
+      },
+      findOneAndUpdate: async () => {
+        throw new Error('enqueue cache proof should not upsert cache entries')
+      },
+    },
+  })
+  mockModule(publisherPath, {
+    __esModule: true,
+    default: async (job) => {
+      publishedJobs.push(job)
+    },
+  })
+  mockModule(abusePath, {
+    checkTranscriptionAbuseLimits: async () => undefined,
+  })
+  mockModule(accessPath, {
+    TranscriptionAccessDenialReason: {
+      membershipCheckFailed: 'membership_check_failed',
+      missingUser: 'missing_user',
+      freeAllowanceExhausted: 'free_allowance_exhausted',
+    },
+    checkTranscriptionAccess: async (params) => {
+      accessCalls.push(params)
+      return accessResult
+    },
+    refundGoldenBorodutchFreeTranscription: async (userId) => {
+      refunds.push(userId)
+    },
+  })
+
+  return {
+    createdJobs,
+    cacheQueries,
+    publishedJobs,
+    accessCalls,
+    refunds,
+  }
+}
+
+async function provesCacheKeyAndTtl() {
+  clearVoicyModules()
+  const {
+    transcriptionResultCacheKey,
+    transcriptionResultCacheTtlSeconds,
+    transcriptionResultCacheExpiresAt,
+  } = require('../dist/helpers/transcriptionJobs/transcriptionResultCache')
+
+  assert.equal(
+    transcriptionResultCacheKey({
+      sourceType: 'voice',
+      file_id: 'volatile-file-id',
+      file_unique_id: 'stable-file-id',
+    }),
+    'telegram:file_unique_id:stable-file-id',
+    'cache key should prefer Telegram file_unique_id'
+  )
+  assert.equal(
+    transcriptionResultCacheKey({
+      sourceType: 'document',
+      file_id: 'fallback-file-id',
+    }),
+    'telegram:document:file_id:fallback-file-id',
+    'cache key should have a safe file_id fallback when unique id is absent'
+  )
+  assert.equal(
+    transcriptionResultCacheTtlSeconds({}),
+    10 * 24 * 60 * 60,
+    'default cache TTL should be 10 days'
+  )
+  assert.equal(
+    transcriptionResultCacheTtlSeconds({
+      VOICY_TRANSCRIPTION_CACHE_TTL_DAYS: '2.5',
+    }),
+    216000,
+    'cache TTL should be configurable in days'
+  )
+
+  const from = new Date('2026-05-07T00:00:00.000Z')
+  assert.equal(
+    transcriptionResultCacheExpiresAt(from, {
+      VOICY_TRANSCRIPTION_CACHE_TTL_DAYS: '1',
+    }).toISOString(),
+    '2026-05-08T00:00:00.000Z',
+    'cache expiry should be derived from the configured TTL'
+  )
+}
+
+async function provesCacheHitPublishesWithoutQueue() {
+  const proof = installHandleAudioMocks({
+    cachedResult: {
+      resultText: 'cached transcript',
+      resultParts: [{ timeCode: '00:00', text: 'cached transcript' }],
+      recognitionLanguage: 'en',
+      workerEngine: 'proof-engine',
+      duration: 1.5,
+      completedAt: new Date('2026-05-07T00:00:00.000Z'),
+    },
+  })
+  const handleAudio = require('../dist/handlers/handleAudio').default
+
+  await handleAudio(mockContext())
+
+  assert.equal(proof.createdJobs.length, 0, 'cache hit must not enqueue a job')
+  assert.equal(proof.publishedJobs.length, 1, 'cache hit should publish result')
+  assert.equal(proof.publishedJobs[0].resultText, 'cached transcript')
+  assert.equal(
+    proof.publishedJobs[0].fileId,
+    'proof-file-id',
+    'cache replay should use the current Telegram file_id, not stored URLs'
+  )
+  assert.equal(
+    proof.cacheQueries[0].cacheKey,
+    'telegram:file_unique_id:proof-file-unique-id'
+  )
+  assert.equal(
+    proof.accessCalls.length,
+    1,
+    'access checks should still run before serving cached results'
+  )
+  assert.deepEqual(
+    proof.refunds,
+    ['67890'],
+    'cache hits should refund free allowance consumed during access checks'
+  )
+}
+
+async function provesEmptyCacheHitPublishesWithoutQueue() {
+  const proof = installHandleAudioMocks({
+    cachedResult: {
+      resultText: '',
+      resultParts: [],
+      completedAt: new Date('2026-05-07T00:00:00.000Z'),
+    },
+    accessResult: { allowed: true, consumedFreeTranscription: false },
+  })
+  const handleAudio = require('../dist/handlers/handleAudio').default
+
+  await handleAudio(mockContext())
+
+  assert.equal(
+    proof.createdJobs.length,
+    0,
+    'empty cache hit must not enqueue a job'
+  )
+  assert.equal(proof.publishedJobs.length, 1, 'empty hit should replay result')
+  assert.equal(
+    proof.publishedJobs[0].resultText,
+    '',
+    'empty/no-speech results should stay cacheable and replayable'
+  )
+}
+
+async function provesCacheMissQueuesJob() {
+  const proof = installHandleAudioMocks({
+    cachedResult: null,
+    accessResult: { allowed: true, consumedFreeTranscription: false },
+  })
+  const handleAudio = require('../dist/handlers/handleAudio').default
+
+  await handleAudio(mockContext({ chatType: 'channel' }))
+
+  assert.equal(proof.createdJobs.length, 1, 'cache miss should enqueue a job')
+  assert.equal(
+    proof.createdJobs[0].status,
+    TRANSCRIPTION_STATUSES.queuedForDownload
+  )
+  assert.equal(
+    proof.createdJobs[0].fileUniqueId,
+    'proof-file-unique-id',
+    'queued jobs should preserve the stable Telegram media id for caching'
+  )
+  assert.equal(
+    proof.publishedJobs.length,
+    0,
+    'cache miss should not publish a cached replay'
+  )
+}
+
+async function provesCompletionCacheUpsertShape() {
+  clearVoicyModules()
+  const cacheModelPath = require.resolve(
+    '../dist/models/TranscriptionResultCache'
+  )
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+  )
+  const upserts = []
+
+  mockModule(cacheModelPath, {
+    TranscriptionResultCacheModel: {
+      findOneAndUpdate: async (...args) => {
+        upserts.push(args)
+      },
+    },
+  })
+  mockModule(publisherPath, {
+    __esModule: true,
+    default: async () => undefined,
+  })
+
+  const {
+    cacheCompletedTranscriptionJob,
+  } = require('../dist/helpers/transcriptionJobs/transcriptionResultCache')
+
+  await cacheCompletedTranscriptionJob({
+    fileId: 'fallback-file-id',
+    fileUniqueId: 'stable-file-id',
+    sourceKind: TRANSCRIPTION_SOURCE_KINDS.voice,
+    resultText: '',
+    resultParts: [],
+    recognitionLanguage: 'en',
+    workerEngine: 'proof-engine',
+    workerEngineMetadata: { model: 'proof-model' },
+    duration: 2,
+    completedAt: new Date('2026-05-07T00:00:00.000Z'),
+  })
+
+  assert.equal(upserts.length, 1, 'completed jobs should upsert cache entries')
+  assert.deepEqual(upserts[0][0], {
+    cacheKey: 'telegram:file_unique_id:stable-file-id',
+  })
+  assert.equal(
+    upserts[0][1].$set.resultText,
+    '',
+    'empty/no-speech results should be stored in cache'
+  )
+  assert(
+    upserts[0][1].$set.expiresAt instanceof Date,
+    'cache entries should carry a TTL expiry date'
+  )
+  assert.deepEqual(upserts[0][2], { upsert: true, new: true })
+}
+
+function provesTtlIndexAndNoFailureCaching() {
+  const modelSource = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'models', 'TranscriptionResultCache.ts'),
+    'utf8'
+  )
+  const jobServiceSource = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'helpers', 'workerApi', 'jobService.ts'),
+    'utf8'
+  )
+
+  assert(
+    modelSource.includes("@index({ expiresAt: 1 }, { expireAfterSeconds: 0 })"),
+    'cache model should define a Mongo TTL index'
+  )
+  assert(
+    jobServiceSource.indexOf('await publishCompletedTranscriptionJob(job)') <
+      jobServiceSource.indexOf('await cacheCompletedTranscriptionJob(job)') &&
+      jobServiceSource.includes(
+        "console.error('Failed to cache completed transcription job', error)"
+      ),
+    'completed results should be cached after final publish without failing completion on cache errors'
+  )
+  assert(
+    !jobServiceSource
+      .slice(jobServiceSource.indexOf('export async function failJob'))
+      .includes('cacheCompletedTranscriptionJob'),
+    'transient/permanent worker failures should not be cached as results'
+  )
+}
+
+async function main() {
+  await provesCacheKeyAndTtl()
+  await provesCacheHitPublishesWithoutQueue()
+  await provesEmptyCacheHitPublishesWithoutQueue()
+  await provesCacheMissQueuesJob()
+  await provesCompletionCacheUpsertShape()
+  provesTtlIndexAndNoFailureCaching()
+  console.log('transcription cache proof passed')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/transcription-finalization-proof.js
+++ b/scripts/transcription-finalization-proof.js
@@ -113,11 +113,16 @@ async function provesCompletionWaitsForPublish() {
   const publisherPath = require.resolve(
     '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
   )
+  const cacheHelperPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/transcriptionResultCache'
+  )
   const jobId = '507f1f77bcf86cd799439011'
   const updates = []
+  const cacheCalls = []
   const workerClient = { _id: { toString: () => 'worker-1' } }
 
   clearModule(jobServicePath)
+  clearModule(cacheHelperPath)
   mockModule(transcriptionJobPath, {
     TranscriptionJobStatus: TRANSCRIPTION_STATUSES,
     TranscriptionJobModel: {
@@ -149,6 +154,11 @@ async function provesCompletionWaitsForPublish() {
     __esModule: true,
     default: async () => undefined,
   })
+  mockModule(cacheHelperPath, {
+    cacheCompletedTranscriptionJob: async (job) => {
+      cacheCalls.push(job)
+    },
+  })
 
   const { completeJob } = require(jobServicePath)
   const job = await completeJob(jobId, workerClient, {
@@ -166,6 +176,7 @@ async function provesCompletionWaitsForPublish() {
     TRANSCRIPTION_STATUSES.completed,
     'job should be completed only after final publish succeeds'
   )
+  assert.equal(cacheCalls.length, 1, 'published jobs should be cached once')
 }
 
 async function provesPublishFailureLeavesJobRetryable() {
@@ -174,12 +185,17 @@ async function provesPublishFailureLeavesJobRetryable() {
   const publisherPath = require.resolve(
     '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
   )
+  const cacheHelperPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/transcriptionResultCache'
+  )
   const jobId = '507f1f77bcf86cd799439012'
   const updates = []
+  const cacheCalls = []
   const workerClient = { _id: { toString: () => 'worker-1' } }
   const originalConsoleError = console.error
 
   clearModule(jobServicePath)
+  clearModule(cacheHelperPath)
   mockModule(transcriptionJobPath, {
     TranscriptionJobStatus: TRANSCRIPTION_STATUSES,
     TranscriptionJobModel: {
@@ -207,6 +223,11 @@ async function provesPublishFailureLeavesJobRetryable() {
       throw new Error('publish failed')
     },
   })
+  mockModule(cacheHelperPath, {
+    cacheCompletedTranscriptionJob: async (job) => {
+      cacheCalls.push(job)
+    },
+  })
 
   const { completeJob } = require(jobServicePath)
   try {
@@ -225,12 +246,89 @@ async function provesPublishFailureLeavesJobRetryable() {
     undefined,
     'publish failure must not convert an in-progress job into completed'
   )
+  assert.equal(
+    cacheCalls.length,
+    0,
+    'publish failures should not write cache entries'
+  )
+}
+
+async function provesCacheFailureDoesNotBlockCompletion() {
+  const jobServicePath = require.resolve('../dist/helpers/workerApi/jobService')
+  const transcriptionJobPath = require.resolve('../dist/models/TranscriptionJob')
+  const publisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+  )
+  const cacheHelperPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/transcriptionResultCache'
+  )
+  const jobId = '507f1f77bcf86cd799439013'
+  const updates = []
+  const workerClient = { _id: { toString: () => 'worker-1' } }
+  const originalConsoleError = console.error
+
+  clearModule(jobServicePath)
+  clearModule(cacheHelperPath)
+  mockModule(transcriptionJobPath, {
+    TranscriptionJobStatus: TRANSCRIPTION_STATUSES,
+    TranscriptionJobModel: {
+      findOneAndUpdate: async (...args) => {
+        updates.push(args)
+        if (updates.length === 1) {
+          return {
+            _id: { toString: () => jobId },
+            status: TRANSCRIPTION_STATUSES.transcribing,
+            workerId: 'worker-1',
+            chatId: 'chat-1',
+            telegramChatId: '123',
+            telegramChatType: 'private',
+            sourceMessageId: 10,
+            statusMessageId: 20,
+            fileId: 'file-1',
+            sourceKind: 'voice',
+            resultText: 'final transcript',
+          }
+        }
+        return {
+          _id: { toString: () => jobId },
+          status: TRANSCRIPTION_STATUSES.completed,
+        }
+      },
+    },
+  })
+  mockModule(publisherPath, {
+    __esModule: true,
+    default: async () => undefined,
+  })
+  mockModule(cacheHelperPath, {
+    cacheCompletedTranscriptionJob: async () => {
+      throw new Error('cache unavailable')
+    },
+  })
+
+  try {
+    console.error = () => undefined
+    const { completeJob } = require(jobServicePath)
+    const job = await completeJob(jobId, workerClient, {
+      text: 'final transcript',
+    })
+    assert.equal(job.status, TRANSCRIPTION_STATUSES.completed)
+  } finally {
+    console.error = originalConsoleError
+  }
+
+  assert.equal(
+    updates[1][1].$set.status,
+    TRANSCRIPTION_STATUSES.completed,
+    'cache failures should not block worker completion'
+  )
 }
 
 async function main() {
   await provesCompletedPublisherFallsBackToFinalMessage()
   await provesCompletionWaitsForPublish()
   await provesPublishFailureLeavesJobRetryable()
+  await provesCacheFailureDoesNotBlockCompletion()
   console.log('transcription finalization proof passed')
 }
 

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -14,7 +14,6 @@ import {
 } from '@/helpers/goldenBorodutchFreeTranscriptions'
 import {
   TranscriptionJobModel,
-  TranscriptionJobSourceKind,
   TranscriptionJobStatus,
 } from '@/models/TranscriptionJob'
 import {
@@ -22,6 +21,10 @@ import {
   markChatUnreachableForTelegramError,
 } from '@/helpers/chatReachability'
 import { markdownI18n } from '@/helpers/telegramMarkdown'
+import {
+  publishCachedTranscriptionResult,
+  sourceKindFromTelegramSourceType,
+} from '@/helpers/transcriptionJobs/transcriptionResultCache'
 import { transcriptionProgressStatusHtml } from '@/helpers/transcriptionJobs/progressStatusText'
 import Context from '@/models/Context'
 import report from '@/helpers/report'
@@ -129,6 +132,26 @@ async function enqueueTranscription(
     return undefined
   }
 
+  try {
+    const servedFromCache = await publishCachedTranscriptionResult({
+      ctx,
+      media: audio,
+      sourceMessage,
+    })
+    if (servedFromCache) {
+      if (access.consumedFreeTranscription && freeAccessUserId) {
+        await refundGoldenBorodutchFreeTranscription(freeAccessUserId)
+      }
+      console.info('Served transcription result from cache')
+      return undefined
+    }
+  } catch (error) {
+    if (access.consumedFreeTranscription && freeAccessUserId) {
+      await refundGoldenBorodutchFreeTranscription(freeAccessUserId)
+    }
+    throw error
+  }
+
   let queuedJob
   try {
     queuedJob = await TranscriptionJobModel.create({
@@ -145,7 +168,7 @@ async function enqueueTranscription(
       mimeType: audio.mime_type,
       fileName: audio.file_name,
       fileUniqueId: fileUniqueId(audio),
-      sourceKind: sourceKind(audio.sourceType),
+      sourceKind: sourceKindFromTelegramSourceType(audio.sourceType),
       requestedByUserId: ctx.from?.id ? String(ctx.from.id) : undefined,
       forwardedFromUserId: sourceMessage.forward_from?.id
         ? String(sourceMessage.forward_from.id)
@@ -290,13 +313,6 @@ function transcriptionAccessMessageKey(
     return 'golden_borodutch_membership_check_failed'
   }
   return 'golden_borodutch_subscription_required'
-}
-
-function sourceKind(sourceType: TranscribableTelegramFile['sourceType']) {
-  if (sourceType === 'video_note') {
-    return TranscriptionJobSourceKind.videoNote
-  }
-  return sourceType as TranscriptionJobSourceKind
 }
 
 function fileUniqueId(audio: TranscribableTelegramFile) {

--- a/src/helpers/transcriptionJobs/transcriptionResultCache.ts
+++ b/src/helpers/transcriptionJobs/transcriptionResultCache.ts
@@ -1,0 +1,156 @@
+import { DocumentType } from '@typegoose/typegoose'
+import { Message } from '@grammyjs/types'
+import {
+  TranscribableTelegramFile,
+  TranscribableTelegramSourceType,
+} from '@/helpers/transcribableTelegramMedia'
+import {
+  TranscriptionJob,
+  TranscriptionJobSourceKind,
+  TranscriptionJobStatus,
+} from '@/models/TranscriptionJob'
+import {
+  TranscriptionResultCache,
+  TranscriptionResultCacheModel,
+} from '@/models/TranscriptionResultCache'
+import Context from '@/models/Context'
+import publishCompletedTranscriptionJob from '@/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+
+const DEFAULT_CACHE_TTL_DAYS = 10
+const SECONDS_PER_DAY = 24 * 60 * 60
+
+export function transcriptionResultCacheTtlSeconds(
+  env: NodeJS.ProcessEnv = process.env
+) {
+  const configuredDays = Number(env.VOICY_TRANSCRIPTION_CACHE_TTL_DAYS)
+  const days =
+    Number.isFinite(configuredDays) && configuredDays > 0
+      ? configuredDays
+      : DEFAULT_CACHE_TTL_DAYS
+  return Math.round(days * SECONDS_PER_DAY)
+}
+
+export function transcriptionResultCacheExpiresAt(
+  from = new Date(),
+  env: NodeJS.ProcessEnv = process.env
+) {
+  return new Date(
+    from.getTime() + transcriptionResultCacheTtlSeconds(env) * 1000
+  )
+}
+
+export function sourceKindFromTelegramSourceType(
+  sourceType: TranscribableTelegramSourceType
+) {
+  if (sourceType === 'video_note') {
+    return TranscriptionJobSourceKind.videoNote
+  }
+  return sourceType as TranscriptionJobSourceKind
+}
+
+export function transcriptionResultCacheKey(
+  media: Pick<
+    TranscribableTelegramFile,
+    'file_id' | 'file_unique_id' | 'sourceType'
+  >
+) {
+  if (media.file_unique_id) {
+    return `telegram:file_unique_id:${media.file_unique_id}`
+  }
+  return `telegram:${media.sourceType}:file_id:${media.file_id}`
+}
+
+function transcriptionResultCacheKeyFromJob(job: TranscriptionJob) {
+  if (job.fileUniqueId) {
+    return `telegram:file_unique_id:${job.fileUniqueId}`
+  }
+  return `telegram:${job.sourceKind}:file_id:${job.fileId}`
+}
+
+export async function cacheCompletedTranscriptionJob(
+  job: DocumentType<TranscriptionJob>
+) {
+  const cacheKey = transcriptionResultCacheKeyFromJob(job)
+  await TranscriptionResultCacheModel.findOneAndUpdate(
+    { cacheKey },
+    {
+      $set: {
+        cacheKey,
+        fileUniqueId: job.fileUniqueId,
+        sourceKind: job.sourceKind,
+        resultText: job.resultText,
+        resultParts: job.resultParts,
+        recognitionLanguage: job.recognitionLanguage,
+        workerEngine: job.workerEngine,
+        workerEngineMetadata: job.workerEngineMetadata,
+        duration: job.duration,
+        completedAt: job.completedAt || new Date(),
+        expiresAt: transcriptionResultCacheExpiresAt(),
+      },
+    },
+    { upsert: true, new: true }
+  )
+}
+
+export function cachedTranscriptionResult(media: TranscribableTelegramFile) {
+  return TranscriptionResultCacheModel.findOne({
+    cacheKey: transcriptionResultCacheKey(media),
+    expiresAt: { $gt: new Date() },
+  })
+}
+
+export async function publishCachedTranscriptionResult({
+  ctx,
+  media,
+  sourceMessage,
+}: {
+  ctx: Context
+  media: TranscribableTelegramFile
+  sourceMessage: Message
+}) {
+  const cached = await cachedTranscriptionResult(media)
+  if (!cached) {
+    return false
+  }
+
+  await publishCompletedTranscriptionJob(
+    cachedReplayJob(ctx, media, sourceMessage, cached)
+  )
+  return true
+}
+
+function cachedReplayJob(
+  ctx: Context,
+  media: TranscribableTelegramFile,
+  sourceMessage: Message,
+  cached: DocumentType<TranscriptionResultCache>
+) {
+  return {
+    status: TranscriptionJobStatus.completed,
+    chatId: ctx.dbchat.id,
+    telegramChatId: String(ctx.chat.id),
+    telegramChatType: ctx.chat.type,
+    sourceMessageId: sourceMessage.message_id,
+    requestMessageId: ctx.msg?.message_id,
+    silent: ctx.dbchat.silent,
+    fileId: media.file_id,
+    fileUniqueId: media.file_unique_id,
+    fileSize: media.file_size,
+    mimeType: media.mime_type,
+    fileName: media.file_name,
+    sourceKind: sourceKindFromTelegramSourceType(media.sourceType),
+    requestedByUserId: ctx.from?.id ? String(ctx.from.id) : undefined,
+    forwardedFromUserId: sourceMessage.forward_from?.id
+      ? String(sourceMessage.forward_from.id)
+      : undefined,
+    forwardedSenderName: sourceMessage.forward_sender_name,
+    uiLocale: ctx.dbchat.uiLanguage,
+    resultText: cached.resultText,
+    resultParts: cached.resultParts,
+    recognitionLanguage: cached.recognitionLanguage,
+    workerEngine: cached.workerEngine,
+    workerEngineMetadata: cached.workerEngineMetadata,
+    duration: cached.duration,
+    completedAt: cached.completedAt || new Date(),
+  } as DocumentType<TranscriptionJob>
+}

--- a/src/helpers/workerApi/jobService.ts
+++ b/src/helpers/workerApi/jobService.ts
@@ -8,6 +8,7 @@ import {
 } from '@/models/TranscriptionJob'
 import { Types } from 'mongoose'
 import { WorkerClient, WorkerClientModel } from '@/models/WorkerClient'
+import { cacheCompletedTranscriptionJob } from '@/helpers/transcriptionJobs/transcriptionResultCache'
 import { safeWorkerSourceUrl } from '@/helpers/sourceUrlSecurity'
 import publishCompletedTranscriptionJob from '@/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
 import publishTranscriptionJobProgress from '@/helpers/transcriptionJobs/publishTranscriptionJobProgress'
@@ -488,6 +489,12 @@ export async function completeJob(
   } catch (error) {
     console.error('Failed to publish completed transcription job', error)
     throw error
+  }
+
+  try {
+    await cacheCompletedTranscriptionJob(job)
+  } catch (error) {
+    console.error('Failed to cache completed transcription job', error)
   }
 
   const completedJob = await TranscriptionJobModel.findOneAndUpdate(

--- a/src/models/TranscriptionResultCache.ts
+++ b/src/models/TranscriptionResultCache.ts
@@ -1,0 +1,48 @@
+import { Schema } from 'mongoose'
+import {
+  Severity,
+  getModelForClass,
+  index,
+  modelOptions,
+  prop,
+} from '@typegoose/typegoose'
+import {
+  TranscriptionJobSourceKind,
+  TranscriptionResultPart,
+  WorkerEngineMetadata,
+} from '@/models/TranscriptionJob'
+
+@index({ cacheKey: 1 }, { unique: true })
+@index({ expiresAt: 1 }, { expireAfterSeconds: 0 })
+@modelOptions({
+  schemaOptions: { timestamps: true },
+  options: { allowMixed: Severity.ALLOW },
+})
+export class TranscriptionResultCache {
+  @prop({ required: true })
+  cacheKey: string
+  @prop()
+  fileUniqueId?: string
+  @prop({ required: true, enum: TranscriptionJobSourceKind })
+  sourceKind: TranscriptionJobSourceKind
+  @prop()
+  resultText?: string
+  @prop({ type: Schema.Types.Mixed })
+  resultParts?: TranscriptionResultPart[]
+  @prop()
+  recognitionLanguage?: string
+  @prop()
+  workerEngine?: string
+  @prop({ type: Schema.Types.Mixed })
+  workerEngineMetadata?: WorkerEngineMetadata
+  @prop()
+  duration?: number
+  @prop()
+  completedAt?: Date
+  @prop({ required: true })
+  expiresAt: Date
+}
+
+export const TranscriptionResultCacheModel = getModelForClass(
+  TranscriptionResultCache
+)


### PR DESCRIPTION
## Summary
- add a Mongo-backed transcription result cache keyed by Telegram file_unique_id with file_id fallback and a configurable 10-day TTL
- replay cached completed and empty/no-speech results through the existing final publisher before creating worker jobs
- cache completed worker results after final publish succeeds while keeping cache write failures non-fatal
- add focused cache proof coverage and update adjacent finalization/donation proofs

## Validation
- yarn build-ts
- yarn lint
- yarn test:transcription-cache
- yarn test:transcription-finalization
- yarn test:donation-wall
- yarn test:error-empty-handling
- yarn test:media-coverage
- yarn test:silent-mode

Blocked locally:
- yarn test:worker-api requires MONGO; workspace has no MONGO env configured

## Manual QA Handoff
Recommended Telegram QA after deploy/test bot: send the same voice/audio media twice in a paid or otherwise allowed private chat and group. The first request should create one worker job and deliver the transcript; the second should return the cached final result immediately with no new worker job. Repeat with an empty/no-speech fixture and verify the second request uses the normal empty/no-speech behavior without a worker job. Also verify /silent still sends only the final transcript for non-empty audio and suppresses empty fallback as before.

Follow-up:
- VOI-KANEO-62 was created for in-flight/concurrent duplicate request dedupe; this PR covers completed-result caching.