### PR TITLE
Log final worker transcription result

### DIFF
--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -226,15 +226,18 @@ backticks, and parentheses in paths and prevents shell expansion.
 `scripts/whisper-transcriber.js` reads `VOICY_WORKER_MODEL` directly, so it does
 not need `{model}` in the args array.
 
-The worker logs transcription activity without transcript text, tokens, or
-source URLs. For each job, the Windows service log includes command start,
-command completion, result upload, and final completion lines with `jobId`,
-`chatId`, `telegramChatId`, `sourceKind`, file size, requested/detected
-language, attempt count, local input/output file names, elapsed command time,
-text character count, empty-result status, part count, and optional audio
-duration. Use these lines to confirm that the Windows host is actively
-transcribing and uploading results while keeping media URLs, worker tokens, raw
-audio, and transcript text out of logs.
+The worker logs transcription activity without tokens or source URLs. For each
+job, the Windows service log includes command start, command completion, result
+upload, and final completion lines with `jobId`, `chatId`, `telegramChatId`,
+`sourceKind`, file size, requested/detected language, attempt count, local
+input/output file names, elapsed command time, text character count,
+empty-result status, part count, and optional audio duration. The final
+completion line also includes `transcriptionResult` with the completed
+transcript text; empty/no-speech results are logged as
+`transcriptionResult=""` with `emptyResult=true`. Use these lines to confirm
+that the Windows host is actively transcribing and uploading results while
+keeping media URLs, worker tokens, and raw audio out of logs. Token-like secrets
+inside transcript text are redacted before writing to the console or log file.
 
 For persistent Windows Task Scheduler logs, run `yarn worker:run` from a
 PowerShell wrapper that redirects standard output and error to a local file the

--- a/scripts/fake-transcriber.js
+++ b/scripts/fake-transcriber.js
@@ -17,13 +17,15 @@ if (input.length === 0) {
   throw new Error('input file is empty')
 }
 
+const transcriptText =
+  process.env.VOICY_FAKE_TRANSCRIPT_TEXT ||
+  'fake transcript from worker client proof'
+
 fs.writeFileSync(
   outputPath,
   JSON.stringify({
-    text: 'fake transcript from worker client proof',
-    parts: [
-      { timeCode: '00:00', text: 'fake transcript from worker client proof' },
-    ],
+    text: transcriptText,
+    parts: [{ timeCode: '00:00', text: transcriptText }],
     language: 'en',
     duration: 1.5,
     metadata: { model, inputPath, outputPath, argv: process.argv.slice(2) },

--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -461,11 +461,24 @@ async function main() {
     }
     const config = loadConfig(env)
     const logLines = []
-    const processed = await processNextJob(config, {
-      info: (message) => logLines.push(message),
-      warn: (message) => logLines.push(message),
-      error: (message) => logLines.push(message),
-    })
+    const transcriptText =
+      'fake transcript from worker client proof with token 123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabc'
+    const previousFakeTranscriptText = process.env.VOICY_FAKE_TRANSCRIPT_TEXT
+    process.env.VOICY_FAKE_TRANSCRIPT_TEXT = transcriptText
+    let processed
+    try {
+      processed = await processNextJob(config, {
+        info: (message) => logLines.push(message),
+        warn: (message) => logLines.push(message),
+        error: (message) => logLines.push(message),
+      })
+    } finally {
+      if (previousFakeTranscriptText === undefined) {
+        delete process.env.VOICY_FAKE_TRANSCRIPT_TEXT
+      } else {
+        process.env.VOICY_FAKE_TRANSCRIPT_TEXT = previousFakeTranscriptText
+      }
+    }
 
     assert(processed, 'worker should process the claimed job')
     assert(
@@ -473,9 +486,19 @@ async function main() {
         (line) =>
           !line.includes('proof-telegram-token') &&
           !line.includes('api.telegram.org/file') &&
-          !line.includes('fake transcript from worker client proof')
+          !line.includes('123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabc')
       ),
-      'worker activity logs should not include tokens, source URLs, or transcript text'
+      'worker activity logs should not include tokens, source URLs, or unredacted sensitive transcript text'
+    )
+    assert(
+      logLines.some(
+        (line) =>
+          line.includes('Worker transcription job completed') &&
+          line.includes(
+            'transcriptionResult="fake transcript from worker client proof with [redacted-secret]"'
+          )
+      ),
+      'worker completion logs should include redacted final transcript text'
     )
     assert(
       logLines.some(
@@ -519,7 +542,7 @@ async function main() {
           line.includes('Worker transcription command completed') &&
           line.includes('jobId="proof-job"') &&
           line.includes('outputSource="file"') &&
-          line.includes('textChars=40') &&
+          line.includes(`textChars=${transcriptText.length}`) &&
           line.includes('parts=1')
       ),
       'worker should log transcription command completion metrics'
@@ -529,7 +552,9 @@ async function main() {
         (line) =>
           line.includes('Worker transcription result uploading') &&
           line.includes('jobId="proof-job"') &&
-          line.includes('textChars=40') &&
+          line.includes('sourceKind="voice"') &&
+          line.includes('detectedLanguage="en"') &&
+          line.includes(`textChars=${transcriptText.length}`) &&
           line.includes('emptyResult=false')
       ),
       'worker should log transcription result upload metrics'
@@ -539,7 +564,9 @@ async function main() {
         (line) =>
           line.includes('Worker transcription job completed') &&
           line.includes('jobId="proof-job"') &&
-          line.includes('textChars=40') &&
+          line.includes('sourceKind="voice"') &&
+          line.includes('detectedLanguage="en"') &&
+          line.includes(`textChars=${transcriptText.length}`) &&
           line.includes('emptyResult=false')
       ),
       'worker should log transcription job completion metrics'
@@ -555,7 +582,7 @@ async function main() {
     )
     assert(state.result, 'worker should submit a result')
     assert(
-      state.result.text === 'fake transcript from worker client proof',
+      state.result.text === transcriptText,
       'worker should submit transcript text'
     )
     assert(
@@ -620,10 +647,11 @@ async function main() {
       VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
     })
 
+    const emptyLogLines = []
     const processed = await processNextJob(config, {
-      info: () => undefined,
-      warn: () => undefined,
-      error: () => undefined,
+      info: (message) => emptyLogLines.push(message),
+      warn: (message) => emptyLogLines.push(message),
+      error: (message) => emptyLogLines.push(message),
     })
 
     assert(processed, 'worker should process the empty transcript job')
@@ -637,6 +665,15 @@ async function main() {
     assert(
       emptyProof.state.result.text === '',
       'empty transcript should submit empty result text for backend fallback copy'
+    )
+    assert(
+      emptyLogLines.some(
+        (line) =>
+          line.includes('Worker transcription job completed') &&
+          line.includes('emptyResult=true') &&
+          line.includes('transcriptionResult=""')
+      ),
+      'empty transcript completion log should explicitly show an empty final result'
     )
   } finally {
     await close(emptyProof.server)

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -146,6 +146,29 @@ function jobLogContext(job: WorkerJob): Record<string, LogValue> {
   }
 }
 
+function transcriptionResultLogContext(
+  job: WorkerJob,
+  result: TranscriptionOutput,
+  config: WorkerConfig,
+  elapsedMs: number
+): Record<string, LogValue> {
+  return {
+    ...jobLogContext(job),
+    engine: config.engine,
+    model: config.model,
+    detectedLanguage: result.language,
+    elapsedMs,
+    textChars: result.text.length,
+    emptyResult: result.text.length === 0,
+    parts: result.parts?.length || 0,
+    duration: result.duration,
+  }
+}
+
+function transcriptionResultTextForLog(result: TranscriptionOutput) {
+  return redactSensitiveText(result.text)
+}
+
 class WorkerClientError extends Error {
   retryable: boolean
 
@@ -762,25 +785,22 @@ async function transcribeDownloadedJob(
       logger
     )
     logWorkerActivity(logger, 'Worker transcription result uploading', {
-      jobId: job.id,
-      engine: config.engine,
-      model: config.model,
-      language: result.language,
-      elapsedMs: Date.now() - startedAt,
-      textChars: result.text.length,
-      emptyResult: result.text.length === 0,
-      parts: result.parts?.length || 0,
+      ...transcriptionResultLogContext(
+        job,
+        result,
+        config,
+        Date.now() - startedAt
+      ),
     })
     await api.post(`/jobs/${job.id}/result`, result)
     logWorkerActivity(logger, 'Worker transcription job completed', {
-      jobId: job.id,
-      engine: config.engine,
-      model: config.model,
-      language: result.language,
-      elapsedMs: Date.now() - startedAt,
-      textChars: result.text.length,
-      emptyResult: result.text.length === 0,
-      parts: result.parts?.length || 0,
+      ...transcriptionResultLogContext(
+        job,
+        result,
+        config,
+        Date.now() - startedAt
+      ),
+      transcriptionResult: transcriptionResultTextForLog(result),
     })
   } catch (error) {
     const retryable =


### PR DESCRIPTION
## Summary
- log the final worker transcription result on successful completion, including empty/no-speech output as `transcriptionResult=""`
- keep job/source/language/elapsed/result-length context on upload/completion logs
- redact token-like text before writing transcript output to console/log files
- update worker client proof and Windows worker logging notes

## Validation
- `yarn test:worker-client` - passed
- `yarn lint` - passed
- `yarn build-ts` - passed

## Testing Handoff
Automated validation covers final result logging, empty transcript logging, source URL/token suppression, and token-like transcript redaction.

Manual QA required after deployment/update on the Windows worker: run a real worker transcription and confirm both the PowerShell console and `C:\voicy-worker\logs\worker.log` contain `Worker transcription job completed ... transcriptionResult="<final text>"`, with `emptyResult=true transcriptionResult=""` for no-speech output and no worker/bot tokens or Telegram file URLs.