### PR TITLE
Dedupe active transcription jobs by media cache key

### DIFF
--- a/scripts/transcription-cache-proof.js
+++ b/scripts/transcription-cache-proof.js
@@ -11,7 +11,13 @@ const path = require('path')
 
 const TRANSCRIPTION_STATUSES = {
   queuedForDownload: 'queued_for_download',
+  downloading: 'downloading',
+  ready: 'ready',
+  queued: 'queued',
+  processing: 'processing',
+  transcribing: 'transcribing',
   completed: 'completed',
+  failed: 'failed',
 }
 
 const TRANSCRIPTION_SOURCE_KINDS = {
@@ -75,12 +81,16 @@ function mockContext({
 }
 
 function installHandleAudioMocks({
+  activeJob,
   cachedResult,
+  createDuplicateOnConcurrentRequest = false,
   accessResult = { allowed: true, consumedFreeTranscription: true },
 } = {}) {
   clearVoicyModules()
 
-  const transcriptionJobPath = require.resolve('../dist/models/TranscriptionJob')
+  const transcriptionJobPath = require.resolve(
+    '../dist/models/TranscriptionJob'
+  )
   const cacheModelPath = require.resolve(
     '../dist/models/TranscriptionResultCache'
   )
@@ -95,22 +105,53 @@ function installHandleAudioMocks({
   )
 
   const createdJobs = []
+  const activeJobQueries = []
   const cacheQueries = []
   const publishedJobs = []
   const accessCalls = []
   const refunds = []
+  let createCalls = 0
+  let duplicateRaised = false
 
   mockModule(transcriptionJobPath, {
     TranscriptionJobStatus: TRANSCRIPTION_STATUSES,
+    activeTranscriptionJobStatuses: [
+      TRANSCRIPTION_STATUSES.queuedForDownload,
+      TRANSCRIPTION_STATUSES.downloading,
+      TRANSCRIPTION_STATUSES.ready,
+      TRANSCRIPTION_STATUSES.queued,
+      TRANSCRIPTION_STATUSES.processing,
+      TRANSCRIPTION_STATUSES.transcribing,
+    ],
     TranscriptionJobSourceKind: TRANSCRIPTION_SOURCE_KINDS,
     TranscriptionJobModel: {
       create: async (job) => {
+        if (createDuplicateOnConcurrentRequest && createCalls > 0) {
+          duplicateRaised = true
+          throw {
+            code: 11000,
+            keyPattern: { activeMediaCacheKey: 1 },
+            message: 'E11000 duplicate key error activeMediaCacheKey',
+          }
+        }
+        createCalls += 1
         const jobDoc = {
+          _id: `created-job-${createdJobs.length + 1}`,
           ...job,
           save: async () => undefined,
         }
         createdJobs.push(jobDoc)
+        if (createDuplicateOnConcurrentRequest) {
+          await new Promise((resolve) => setTimeout(resolve, 5))
+        }
         return jobDoc
+      },
+      findOne: async (query) => {
+        activeJobQueries.push(query)
+        if (duplicateRaised && createdJobs[0]) {
+          return createdJobs[0]
+        }
+        return activeJob || null
       },
     },
   })
@@ -151,6 +192,7 @@ function installHandleAudioMocks({
 
   return {
     createdJobs,
+    activeJobQueries,
     cacheQueries,
     publishedJobs,
     accessCalls,
@@ -291,9 +333,84 @@ async function provesCacheMissQueuesJob() {
     'queued jobs should preserve the stable Telegram media id for caching'
   )
   assert.equal(
+    proof.createdJobs[0].mediaCacheKey,
+    'telegram:file_unique_id:proof-file-unique-id',
+    'queued jobs should store the stable media cache key'
+  )
+  assert.equal(
+    proof.createdJobs[0].activeMediaCacheKey,
+    'telegram:file_unique_id:proof-file-unique-id',
+    'queued jobs should hold the active media dedupe lock'
+  )
+  assert.equal(
     proof.publishedJobs.length,
     0,
     'cache miss should not publish a cached replay'
+  )
+}
+
+async function provesActiveJobDedupeSkipsNewQueue() {
+  const proof = installHandleAudioMocks({
+    activeJob: {
+      _id: 'active-job-id',
+      status: TRANSCRIPTION_STATUSES.queuedForDownload,
+      activeMediaCacheKey: 'telegram:file_unique_id:proof-file-unique-id',
+    },
+  })
+  const handleAudio = require('../dist/handlers/handleAudio').default
+
+  await handleAudio(mockContext({ chatType: 'channel' }))
+
+  assert.equal(
+    proof.createdJobs.length,
+    0,
+    'active in-flight media should not enqueue another worker job'
+  )
+  assert.deepEqual(proof.activeJobQueries[0], {
+    activeMediaCacheKey: 'telegram:file_unique_id:proof-file-unique-id',
+    status: {
+      $in: [
+        TRANSCRIPTION_STATUSES.queuedForDownload,
+        TRANSCRIPTION_STATUSES.downloading,
+        TRANSCRIPTION_STATUSES.ready,
+        TRANSCRIPTION_STATUSES.queued,
+        TRANSCRIPTION_STATUSES.processing,
+        TRANSCRIPTION_STATUSES.transcribing,
+      ],
+    },
+  })
+  assert.deepEqual(
+    proof.refunds,
+    ['67890'],
+    'active in-flight dedupe should refund free allowance consumed during access checks'
+  )
+}
+
+async function provesConcurrentCacheMissesCreateOneWorkerJob() {
+  const proof = installHandleAudioMocks({
+    cachedResult: null,
+    createDuplicateOnConcurrentRequest: true,
+  })
+  const handleAudio = require('../dist/handlers/handleAudio').default
+
+  await Promise.all([
+    handleAudio(mockContext({ chatType: 'channel' })),
+    handleAudio(mockContext({ chatType: 'channel' })),
+  ])
+
+  assert.equal(
+    proof.createdJobs.length,
+    1,
+    'two concurrent misses for one file_unique_id should create one worker job'
+  )
+  assert.equal(
+    proof.createdJobs[0].activeMediaCacheKey,
+    'telegram:file_unique_id:proof-file-unique-id'
+  )
+  assert.deepEqual(
+    proof.refunds,
+    ['67890'],
+    'the deduped concurrent request should refund consumed free allowance'
   )
 }
 
@@ -363,8 +480,23 @@ function provesTtlIndexAndNoFailureCaching() {
   )
 
   assert(
-    modelSource.includes("@index({ expiresAt: 1 }, { expireAfterSeconds: 0 })"),
+    modelSource.includes('@index({ expiresAt: 1 }, { expireAfterSeconds: 0 })'),
     'cache model should define a Mongo TTL index'
+  )
+  assert(
+    fs
+      .readFileSync(
+        path.join(__dirname, '..', 'src', 'models', 'TranscriptionJob.ts'),
+        'utf8'
+      )
+      .includes('partialFilterExpression') &&
+      fs
+        .readFileSync(
+          path.join(__dirname, '..', 'src', 'models', 'TranscriptionJob.ts'),
+          'utf8'
+        )
+        .includes('activeMediaCacheKey'),
+    'transcription jobs should define a unique active media dedupe lock index'
   )
   assert(
     jobServiceSource.indexOf('await publishCompletedTranscriptionJob(job)') <
@@ -380,6 +512,85 @@ function provesTtlIndexAndNoFailureCaching() {
       .includes('cacheCompletedTranscriptionJob'),
     'transient/permanent worker failures should not be cached as results'
   )
+  assert(
+    jobServiceSource.includes(
+      "$unset: { lastError: '', activeMediaCacheKey: '' }"
+    ),
+    'completed jobs should release the active media dedupe lock'
+  )
+  assert(
+    jobServiceSource
+      .slice(jobServiceSource.indexOf('status: TranscriptionJobStatus.failed'))
+      .includes("activeMediaCacheKey: ''"),
+    'failed non-retry jobs should release the active media dedupe lock'
+  )
+}
+
+async function provesFinalFailuresReleaseActiveDedupeLock() {
+  clearVoicyModules()
+  const transcriptionJobPath = require.resolve(
+    '../dist/models/TranscriptionJob'
+  )
+  const workerClientPath = require.resolve('../dist/models/WorkerClient')
+  const cacheHelperPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/transcriptionResultCache'
+  )
+  const completedPublisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishCompletedTranscriptionJob'
+  )
+  const progressPublisherPath = require.resolve(
+    '../dist/helpers/transcriptionJobs/publishTranscriptionJobProgress'
+  )
+  const updates = []
+  const ownedJob = {
+    _id: '507f1f77bcf86cd799439011',
+    workerId: 'worker-id',
+    attempts: 3,
+    status: TRANSCRIPTION_STATUSES.transcribing,
+    activeMediaCacheKey: 'telegram:file_unique_id:proof-file-unique-id',
+  }
+
+  mockModule(transcriptionJobPath, {
+    TranscriptionJobStatus: TRANSCRIPTION_STATUSES,
+    TranscriptionJobModel: {
+      findOne: async () => ownedJob,
+      findOneAndUpdate: async (query, update, options) => {
+        updates.push({ query, update, options })
+        return {
+          ...ownedJob,
+          ...update.$set,
+        }
+      },
+    },
+  })
+  mockModule(workerClientPath, {
+    WorkerClientModel: {},
+  })
+  mockModule(cacheHelperPath, {
+    cacheCompletedTranscriptionJob: async () => undefined,
+  })
+  mockModule(completedPublisherPath, {
+    __esModule: true,
+    default: async () => undefined,
+  })
+  mockModule(progressPublisherPath, {
+    __esModule: true,
+    default: async () => undefined,
+  })
+
+  const { failJob } = require('../dist/helpers/workerApi/jobService')
+  await failJob(
+    '507f1f77bcf86cd799439011',
+    { _id: { toString: () => 'worker-id' } },
+    { retryable: false, error: 'proof failure' }
+  )
+
+  assert.equal(updates.length, 1, 'final failure should persist one update')
+  assert.deepEqual(
+    updates[0].update.$unset,
+    { activeMediaCacheKey: '' },
+    'final failed jobs should release the active media dedupe lock so later requests can queue'
+  )
 }
 
 async function main() {
@@ -387,8 +598,11 @@ async function main() {
   await provesCacheHitPublishesWithoutQueue()
   await provesEmptyCacheHitPublishesWithoutQueue()
   await provesCacheMissQueuesJob()
+  await provesActiveJobDedupeSkipsNewQueue()
+  await provesConcurrentCacheMissesCreateOneWorkerJob()
   await provesCompletionCacheUpsertShape()
   provesTtlIndexAndNoFailureCaching()
+  await provesFinalFailuresReleaseActiveDedupeLock()
   console.log('transcription cache proof passed')
 }
 

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -15,6 +15,7 @@ import {
 import {
   TranscriptionJobModel,
   TranscriptionJobStatus,
+  activeTranscriptionJobStatuses,
 } from '@/models/TranscriptionJob'
 import {
   chatCanQueueTranscriptions,
@@ -24,6 +25,7 @@ import { markdownI18n } from '@/helpers/telegramMarkdown'
 import {
   publishCachedTranscriptionResult,
   sourceKindFromTelegramSourceType,
+  transcriptionResultCacheKey,
 } from '@/helpers/transcriptionJobs/transcriptionResultCache'
 import { transcriptionProgressStatusHtml } from '@/helpers/transcriptionJobs/progressStatusText'
 import Context from '@/models/Context'
@@ -152,6 +154,18 @@ async function enqueueTranscription(
     throw error
   }
 
+  const mediaCacheKey = transcriptionResultCacheKey(audio)
+  const existingActiveJob = await findActiveTranscriptionJob(mediaCacheKey)
+  if (existingActiveJob) {
+    if (access.consumedFreeTranscription && freeAccessUserId) {
+      await refundGoldenBorodutchFreeTranscription(freeAccessUserId)
+    }
+    console.info(
+      `Deduped transcription request against active job ${existingActiveJob._id}`
+    )
+    return existingActiveJob
+  }
+
   let queuedJob
   try {
     queuedJob = await TranscriptionJobModel.create({
@@ -168,6 +182,8 @@ async function enqueueTranscription(
       mimeType: audio.mime_type,
       fileName: audio.file_name,
       fileUniqueId: fileUniqueId(audio),
+      mediaCacheKey,
+      activeMediaCacheKey: mediaCacheKey,
       sourceKind: sourceKindFromTelegramSourceType(audio.sourceType),
       requestedByUserId: ctx.from?.id ? String(ctx.from.id) : undefined,
       forwardedFromUserId: sourceMessage.forward_from?.id
@@ -177,6 +193,16 @@ async function enqueueTranscription(
       uiLocale: ctx.dbchat.uiLanguage,
     })
   } catch (error) {
+    if (isDuplicateActiveMediaCacheKeyError(error)) {
+      if (access.consumedFreeTranscription && freeAccessUserId) {
+        await refundGoldenBorodutchFreeTranscription(freeAccessUserId)
+      }
+      const activeJob = await findActiveTranscriptionJob(mediaCacheKey)
+      console.info(
+        `Deduped concurrent transcription request for ${mediaCacheKey}`
+      )
+      return activeJob || undefined
+    }
     if (access.consumedFreeTranscription && freeAccessUserId) {
       await refundGoldenBorodutchFreeTranscription(freeAccessUserId)
     }
@@ -189,6 +215,7 @@ async function enqueueTranscription(
       queuedJob.status = TranscriptionJobStatus.failed
       queuedJob.failedAt = new Date()
       queuedJob.lastError = 'Telegram chat is unreachable for transcription'
+      queuedJob.activeMediaCacheKey = undefined
       await queuedJob.save()
     }
     console.info('Skipping live transcription status message in silent mode')
@@ -223,6 +250,7 @@ async function enqueueTranscription(
       queuedJob.status = TranscriptionJobStatus.failed
       queuedJob.failedAt = new Date()
       queuedJob.lastError = 'Telegram chat is unreachable for transcription'
+      queuedJob.activeMediaCacheKey = undefined
       await queuedJob.save()
     }
     report(error, { ctx, location: 'ackQueuedTranscription' })
@@ -317,6 +345,26 @@ function transcriptionAccessMessageKey(
 
 function fileUniqueId(audio: TranscribableTelegramFile) {
   return 'file_unique_id' in audio ? audio.file_unique_id : undefined
+}
+
+function findActiveTranscriptionJob(mediaCacheKey: string) {
+  return TranscriptionJobModel.findOne({
+    activeMediaCacheKey: mediaCacheKey,
+    status: { $in: activeTranscriptionJobStatuses },
+  })
+}
+
+function isDuplicateActiveMediaCacheKeyError(error: unknown) {
+  const mongoError = error as {
+    code?: number
+    keyPattern?: Record<string, unknown>
+    message?: string
+  }
+  return (
+    mongoError.code === 11000 &&
+    (Boolean(mongoError.keyPattern?.activeMediaCacheKey) ||
+      Boolean(mongoError.message?.includes('activeMediaCacheKey')))
+  )
 }
 
 async function sendSilentTranscriptionChatAction(ctx: Context) {

--- a/src/helpers/transcriptionJobs/abuseLimits.ts
+++ b/src/helpers/transcriptionJobs/abuseLimits.ts
@@ -1,6 +1,6 @@
 import {
   TranscriptionJobModel,
-  TranscriptionJobStatus,
+  activeTranscriptionJobStatuses,
 } from '@/models/TranscriptionJob'
 
 export enum TranscriptionAbuseLimitReason {
@@ -34,15 +34,6 @@ interface CheckTranscriptionAbuseLimitOptions {
   settings?: TranscriptionAbuseLimitSettings
   counter?: Counter
 }
-
-const activeStatuses = [
-  TranscriptionJobStatus.queuedForDownload,
-  TranscriptionJobStatus.downloading,
-  TranscriptionJobStatus.ready,
-  TranscriptionJobStatus.queued,
-  TranscriptionJobStatus.processing,
-  TranscriptionJobStatus.transcribing,
-]
 
 export function transcriptionAbuseLimitSettings(
   env: NodeJS.ProcessEnv = process.env
@@ -83,7 +74,7 @@ export async function checkTranscriptionAbuseLimits({
   if (settings.chatActiveJobLimit > 0) {
     const activeJobs = await counter.countDocuments({
       chatId,
-      status: { $in: activeStatuses },
+      status: { $in: activeTranscriptionJobStatuses },
     })
     if (activeJobs >= settings.chatActiveJobLimit) {
       return {
@@ -138,5 +129,3 @@ function numberFromEnv(value: string | undefined, fallback: number) {
 function windowStart(now: Date, windowMs: number) {
   return new Date(now.getTime() - windowMs)
 }
-
-export { activeStatuses as activeTranscriptionJobStatuses }

--- a/src/helpers/workerApi/jobService.ts
+++ b/src/helpers/workerApi/jobService.ts
@@ -514,7 +514,7 @@ export async function completeJob(
         heartbeatAt: now,
         completedAt: now,
       },
-      $unset: { lastError: '' },
+      $unset: { lastError: '', activeMediaCacheKey: '' },
     },
     { new: true }
   )
@@ -555,6 +555,9 @@ export async function failJob(
           lastError: truncateError(body.error),
           heartbeatAt: now,
           failedAt: now,
+        },
+        $unset: {
+          activeMediaCacheKey: '',
         },
       }
 

--- a/src/models/TranscriptionJob.ts
+++ b/src/models/TranscriptionJob.ts
@@ -18,6 +18,15 @@ export enum TranscriptionJobStatus {
   failed = 'failed',
 }
 
+export const activeTranscriptionJobStatuses = [
+  TranscriptionJobStatus.queuedForDownload,
+  TranscriptionJobStatus.downloading,
+  TranscriptionJobStatus.ready,
+  TranscriptionJobStatus.queued,
+  TranscriptionJobStatus.processing,
+  TranscriptionJobStatus.transcribing,
+]
+
 export enum TranscriptionJobSourceKind {
   voice = 'voice',
   videoNote = 'video_note',
@@ -41,6 +50,15 @@ export interface WorkerEngineMetadata {
 @index({ status: 1, createdAt: 1 })
 @index({ workerId: 1, status: 1 })
 @index({ chatId: 1, sourceMessageId: 1 })
+@index(
+  { activeMediaCacheKey: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      activeMediaCacheKey: { $type: 'string' },
+    },
+  }
+)
 @modelOptions({
   schemaOptions: { timestamps: true },
   options: { allowMixed: Severity.ALLOW },
@@ -73,6 +91,10 @@ export class TranscriptionJob {
   fileId: string
   @prop()
   fileUniqueId?: string
+  @prop({ index: true })
+  mediaCacheKey?: string
+  @prop()
+  activeMediaCacheKey?: string
   @prop()
   filePath?: string
   @prop()


### PR DESCRIPTION
## Summary
- add an active media cache-key lock to transcription jobs with a unique partial Mongo index
- dedupe enqueue attempts before creating a worker job and handle concurrent duplicate-key races
- release the active lock when jobs complete or permanently fail, while preserving completed result-cache replay

## Validation
- yarn build-ts
- yarn test:transcription-cache
- yarn lint
- yarn test:worker-api (blocked: MONGO is required for the worker API proof)

Manual QA: not required for this change; deterministic proof covers cache hit replay, concurrent duplicate creation, active job dedupe, and final failure lock release without Telegram UI changes.