### PR TITLE
Retry final transcript publishes without reply target

### DIFF
--- a/scripts/error-empty-handling-proof.js
+++ b/scripts/error-empty-handling-proof.js
@@ -148,6 +148,11 @@ assert(
   'completed voice records should store normalized transcript text'
 )
 assert(
+  publishSource.includes('replyOptions.reply_to_message_id') &&
+    publishSource.includes('await bot.api.sendMessage(job.telegramChatId, text)'),
+  'completed publisher should retry final transcript messages without a reply target'
+)
+assert(
   !publishSource.includes('editMessageCaption'),
   'completed publisher should not mutate original media captions'
 )

--- a/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
+++ b/src/helpers/transcriptionJobs/publishCompletedTranscriptionJob.ts
@@ -13,6 +13,10 @@ import {
 import bot from '@/helpers/bot'
 import localizedTranscriptionText from '@/helpers/localizedTranscriptionText'
 
+type FinalReplyOptions = {
+  reply_to_message_id?: number
+}
+
 async function storeVoiceRecord(job: DocumentType<TranscriptionJob>) {
   await VoiceModel.findOneAndUpdate(
     { chatId: job.chatId, messageId: job.sourceMessageId },
@@ -120,13 +124,30 @@ export default async function publishCompletedTranscriptionJob(
 async function sendFinalMessage(
   job: DocumentType<TranscriptionJob>,
   text: string,
-  replyOptions: Record<string, number>
+  replyOptions: FinalReplyOptions
 ) {
   try {
     await bot.api.sendMessage(job.telegramChatId, text, {
       ...replyOptions,
     })
   } catch (error) {
+    if (replyOptions.reply_to_message_id) {
+      try {
+        await bot.api.sendMessage(job.telegramChatId, text)
+        return
+      } catch (fallbackError) {
+        await markChatUnreachableByIdForTelegramError(
+          job.chatId,
+          fallbackError,
+          {
+            location: 'publishCompletedTranscriptionJob',
+            action: 'sendMessage',
+          }
+        )
+        throw fallbackError
+      }
+    }
+
     await markChatUnreachableByIdForTelegramError(job.chatId, error, {
       location: 'publishCompletedTranscriptionJob',
       action: 'sendMessage',


### PR DESCRIPTION
## Summary
- retry final transcript Telegram sends without reply_to_message_id when the reply-targeted send fails
- keep permanent unreachable marking on fallback send failures
- add proof coverage so final transcript publisher keeps the no-reply fallback

## Validation
- yarn build-ts
- yarn test:error-empty-handling
- yarn lint