### PR TITLE
Accept valid transcript output from nonzero worker commands

### DIFF
--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -755,6 +755,71 @@ async function main() {
     await close(emptyProof.server)
   }
 
+  const nonZeroOutputProof = createProofServer()
+  await listen(nonZeroOutputProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      nonZeroOutputProof.server.address().port
+    }/worker/v1`
+    const config = loadConfig({
+      VOICY_WORKER_API_URL: baseUrl,
+      VOICY_WORKER_TOKEN: 'proof-worker-token',
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        '-e',
+        [
+          "const fs = require('fs')",
+          "fs.writeFileSync(process.argv[2], JSON.stringify({ text: 'recovered transcript', parts: [], language: 'en', duration: 1 }))",
+          'process.exit(7)',
+        ].join('; '),
+        '{input}',
+        '{output}',
+      ]),
+      VOICY_WORKER_WORK_DIR: path.join(
+        os.tmpdir(),
+        `voicy-worker-nonzero-output-proof-${process.pid}`
+      ),
+      VOICY_WORKER_TELEGRAM_API_URL: `http://127.0.0.1:${
+        nonZeroOutputProof.server.address().port
+      }`,
+      VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
+    })
+
+    const nonZeroLogLines = []
+    const processed = await processNextJob(config, {
+      info: (message) => nonZeroLogLines.push(message),
+      warn: (message) => nonZeroLogLines.push(message),
+      error: (message) => nonZeroLogLines.push(message),
+    })
+
+    assert(
+      processed,
+      'worker should process the non-zero command with valid output'
+    )
+    assert(
+      !nonZeroOutputProof.state.failure,
+      `non-zero command with valid output should not report failure: ${JSON.stringify(
+        nonZeroOutputProof.state.failure
+      )}`
+    )
+    assert(
+      nonZeroOutputProof.state.result?.text === 'recovered transcript',
+      'worker should submit valid transcript output even when the command exits non-zero'
+    )
+    assert(
+      nonZeroLogLines.some(
+        (line) =>
+          line.includes('Worker transcription command completed') &&
+          line.includes('exitCode=7') &&
+          line.includes('outputSource="file"')
+      ),
+      'worker should log the recovered non-zero exit code with file output'
+    )
+  } finally {
+    await close(nonZeroOutputProof.server)
+  }
+
   const failureProof = createProofServer()
   await listen(failureProof.server)
 

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -94,6 +94,7 @@ interface RunCommandResult {
   stdout: string
   stderr: string
   elapsedMs: number
+  exitCode: number | null
 }
 
 interface DownloadedJob {
@@ -584,17 +585,13 @@ function runCommand(
       const stdout = Buffer.concat(stdoutChunks).toString('utf8')
       const stderr = Buffer.concat(stderrChunks).toString('utf8')
       const elapsedMs = Date.now() - startedAt
-      if (code !== 0) {
-        reject(
-          new WorkerClientError(
-            `Transcription command exited with ${code}; stdoutChars=${stdout.length}; stderrChars=${stderr.length}`
-          )
-        )
-        return
-      }
-      resolve({ stdout, stderr, elapsedMs })
+      resolve({ stdout, stderr, elapsedMs, exitCode: code })
     })
   })
+}
+
+function commandFailureMessage(commandResult: RunCommandResult) {
+  return `Transcription command exited with ${commandResult.exitCode}; stdoutChars=${commandResult.stdout.length}; stderrChars=${commandResult.stderr.length}`
 }
 
 function parseJsonOutput(value: string) {
@@ -654,6 +651,10 @@ async function readTranscriptionOutput(
     model: config.model,
     language: result.language,
     elapsedMs: commandResult.elapsedMs,
+    exitCode:
+      commandResult.exitCode && commandResult.exitCode !== 0
+        ? commandResult.exitCode
+        : undefined,
     outputSource: outputStat ? 'file' : 'stdout',
     textChars: result.text.length,
     parts: result.parts?.length || 0,
@@ -687,6 +688,13 @@ async function transcribeJob(
     args,
     config
   )
+  if (commandResult.exitCode !== 0) {
+    const rawOutput = await readFile(outputPath, 'utf8').catch(() => undefined)
+    const parsed = rawOutput ? parseJsonOutput(rawOutput.trim()) : undefined
+    if (!parsed || typeof parsed.text !== 'string') {
+      throw new WorkerClientError(commandFailureMessage(commandResult))
+    }
+  }
   return readTranscriptionOutput(
     commandResult,
     outputPath,


### PR DESCRIPTION
## Summary
- keep the worker command stdout/stderr diagnostics while allowing valid JSON transcript output files to be submitted even if the transcriber exits non-zero afterward
- log recovered non-zero exit codes on completion for Windows/CUDA diagnostics
- add worker-client proof coverage for a non-zero command that writes a valid transcript file, while preserving failure behavior when no valid output exists

## Validation
- yarn build-ts
- yarn test:worker-client
- yarn lint