### PR TITLE
Harden Windows worker restart supervision

### DIFF
--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -325,11 +325,14 @@ powershell -ExecutionPolicy Bypass -File .\scripts\install-windows-worker.ps1 `
 The installer copies `scripts/run-windows-worker.ps1` to the install root,
 writes `C:\ProgramData\Voicy\worker\worker.env`, ACLs that env file to SYSTEM,
 Administrators, and the installing user, and registers a restartable scheduled
-task that runs as SYSTEM. Re-run the installer after changing worker environment
-variables or after pulling updates to the wrapper script. If the transcription
-stack depends on the installing user's profile instead of explicit paths under
-`C:\voicy-worker`, pass `-RunAsCurrentUser` and verify the task still starts
-after login.
+task that runs as SYSTEM. It persists all `VOICY_*` settings plus common
+runtime variables needed by the Windows transcription stack, including `PATH`,
+Python, CUDA/CTranslate2, OpenMP, and Hugging Face cache variables. Re-run the
+installer after changing worker environment variables or after pulling updates
+to the wrapper script. If Yarn, Python, CUDA DLLs, or model caches are installed
+only in the interactive user's profile, either export explicit machine-visible
+paths before installing or pass `-RunAsCurrentUser` and verify the task still
+starts after login.
 
 Verify the task and logs:
 

--- a/scripts/install-windows-worker.ps1
+++ b/scripts/install-windows-worker.ps1
@@ -47,36 +47,52 @@ if (!(Test-Path -LiteralPath $runScriptSource)) {
 New-Item -ItemType Directory -Force -Path $InstallRoot, $SecretDir, $logDir | Out-Null
 Copy-Item -Force -LiteralPath $runScriptSource -Destination $runScriptTarget
 
-$envNames = @(
+$envNameSet = [ordered]@{}
+
+function Add-EnvName {
+  param([string]$Name)
+
+  if (!$envNameSet.Contains($Name)) {
+    $envNameSet[$Name] = $true
+  }
+}
+
+$requiredEnvNames = @(
   "VOICY_WORKER_API_URL",
   "VOICY_WORKER_TOKEN",
-  "VOICY_WORKER_WORK_DIR",
-  "VOICY_WORKER_ENGINE",
-  "VOICY_WORKER_MODEL",
-  "VOICY_WORKER_HEARTBEAT_INTERVAL_MS",
-  "VOICY_WORKER_POLL_INTERVAL_MS",
-  "VOICY_WORKER_RESTART_DELAY_MS",
-  "VOICY_WORKER_TELEGRAM_BOT_TOKEN",
-  "VOICY_WORKER_TELEGRAM_API_URL",
-  "VOICY_WORKER_DOWNLOAD_CONCURRENCY",
-  "VOICY_WORKER_TRANSCRIPTION_CONCURRENCY",
   "VOICY_WORKER_TRANSCRIBE_EXECUTABLE",
-  "VOICY_WORKER_TRANSCRIBE_ARGS_JSON",
-  "VOICY_WORKER_LANGUAGE",
-  "VOICY_WHISPER_COMMAND",
-  "VOICY_WHISPER_MODEL",
-  "NODE_ENV",
-  "PATH"
+  "VOICY_WORKER_TRANSCRIBE_ARGS_JSON"
 )
 
+foreach ($name in $requiredEnvNames) {
+  Add-EnvName -Name $name
+}
+
+foreach ($envVar in Get-ChildItem Env:) {
+  $name = $envVar.Name
+  if (
+    $name -eq "PATH" -or
+    $name -eq "NODE_ENV" -or
+    $name -eq "PYTHONPATH" -or
+    $name -eq "PYTHONUTF8" -or
+    $name -eq "HF_HOME" -or
+    $name -eq "HUGGINGFACE_HUB_CACHE" -or
+    $name -eq "TRANSFORMERS_CACHE" -or
+    $name.StartsWith("VOICY_") -or
+    $name.StartsWith("CUDA") -or
+    $name.StartsWith("CUBLAS") -or
+    $name.StartsWith("CUDNN") -or
+    $name.StartsWith("CT2_") -or
+    $name.StartsWith("OMP_") -or
+    $name.StartsWith("KMP_")
+  ) {
+    Add-EnvName -Name $name
+  }
+}
+
 $envContent = New-Object System.Collections.Generic.List[string]
-foreach ($name in $envNames) {
-  $value = if ($name -in @(
-      "VOICY_WORKER_API_URL",
-      "VOICY_WORKER_TOKEN",
-      "VOICY_WORKER_TRANSCRIBE_EXECUTABLE",
-      "VOICY_WORKER_TRANSCRIBE_ARGS_JSON"
-    )) {
+foreach ($name in $envNameSet.Keys) {
+  $value = if ($name -in $requiredEnvNames) {
     Require-ProcessEnv -Name $name
   } else {
     Optional-ProcessEnv -Name $name

--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -1051,6 +1051,13 @@ async function main() {
       installerScript.includes('run-windows-worker.ps1'),
     'Windows worker installer should register a restartable scheduled task'
   )
+  assert(
+    installerScript.includes('Get-ChildItem Env:') &&
+      installerScript.includes('$name.StartsWith("CUDA")') &&
+      installerScript.includes('$name.StartsWith("CT2_")') &&
+      installerScript.includes('$name -eq "PATH"'),
+    'Windows worker installer should preserve runtime env needed by CUDA/Python workers'
+  )
 
   console.log('worker client proof passed')
 }

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -915,6 +915,19 @@ export async function processAvailableJobs(
     }
   }
 
+  const waitForActiveWork = async () => {
+    const activeWork = [...downloads, ...transcriptions]
+    if (activeWork.length === 0) {
+      return
+    }
+    try {
+      await Promise.race(activeWork)
+    } catch (error) {
+      await Promise.allSettled(activeWork)
+      throw error
+    }
+  }
+
   let cycleComplete = false
   while (!cycleComplete) {
     await fillDownloads()
@@ -929,7 +942,7 @@ export async function processAvailableJobs(
       continue
     }
 
-    await Promise.race([...downloads, ...transcriptions])
+    await waitForActiveWork()
   }
 
   const legacyJob = processed === 0 ? await claimJob(api) : undefined


### PR DESCRIPTION
## Summary
- preserve Windows worker runtime environment more safely when installing the scheduled-task supervisor, including VOICY, PATH, Python, CUDA/CTranslate2, OpenMP, and Hugging Face cache variables
- drain active download/transcription work before restarting the polling loop after a crash, avoiding overlap with a restarted cycle
- document the env persistence behavior and extend the worker proof for the runtime-env contract

## Validation
- yarn build-ts
- yarn test:worker-client
- PowerShell AST parse for scripts/run-windows-worker.ps1 and scripts/install-windows-worker.ps1
- yarn lint
- git diff --check origin/main...HEAD

Context: follow-up to PR #186 / VOI-64 after review found deployment-safety gaps in the merged version.