### PR TITLE
Bypass transcription throttles for paid chats

### DIFF
--- a/scripts/donation-wall-proof.js
+++ b/scripts/donation-wall-proof.js
@@ -126,12 +126,15 @@ async function withPatchedStripeCheckout(callback) {
   }
 }
 
-async function withPatchedQueue(callback, accessResult) {
+async function withPatchedQueue(callback, accessResult, abuseLimitResult) {
   const originalCreate = TranscriptionJobModel.create
+  const originalFindJob = TranscriptionJobModel.findOne
+  const originalUpdateMany = TranscriptionJobModel.updateMany
   const originalFindCache = TranscriptionResultCacheModel.findOne
   const originalCheckLimits = abuseLimits.checkTranscriptionAbuseLimits
   const originalCheckAccess = goldenBorodutchAllowance.checkTranscriptionAccess
   const createdJobs = []
+  const abuseLimitChecks = []
 
   TranscriptionJobModel.create = async (job) => {
     const jobDoc = {
@@ -148,8 +151,15 @@ async function withPatchedQueue(callback, accessResult) {
     createdJobs.push(jobDoc)
     return jobDoc
   }
+  TranscriptionJobModel.findOne = async () => undefined
+  TranscriptionJobModel.updateMany = async () => ({ modifiedCount: 0 })
   TranscriptionResultCacheModel.findOne = async () => undefined
-  abuseLimits.checkTranscriptionAbuseLimits = async () => undefined
+  abuseLimits.checkTranscriptionAbuseLimits = async (options) => {
+    abuseLimitChecks.push(options)
+    return typeof abuseLimitResult === 'function'
+      ? abuseLimitResult(options)
+      : abuseLimitResult
+  }
   goldenBorodutchAllowance.checkTranscriptionAccess = async () => {
     if (accessResult instanceof Error) {
       throw accessResult
@@ -158,9 +168,11 @@ async function withPatchedQueue(callback, accessResult) {
   }
 
   try {
-    await callback(createdJobs)
+    await callback(createdJobs, abuseLimitChecks)
   } finally {
     TranscriptionJobModel.create = originalCreate
+    TranscriptionJobModel.findOne = originalFindJob
+    TranscriptionJobModel.updateMany = originalUpdateMany
     TranscriptionResultCacheModel.findOne = originalFindCache
     abuseLimits.checkTranscriptionAbuseLimits = originalCheckLimits
     goldenBorodutchAllowance.checkTranscriptionAccess = originalCheckAccess
@@ -214,6 +226,70 @@ async function main() {
       'queued job should use download queue status'
     )
   })
+
+  await withPatchedQueue(
+    async (createdJobs, abuseLimitChecks) => {
+      process.env.VOICY_DONATION_WALL_ENABLED = 'false'
+      const ctx = mockContext({ paid: true, chatType: 'private' })
+      await handleAudio(ctx)
+
+      assert(
+        createdJobs.length === 1,
+        'paid audio should enqueue when abuse counters are over limit'
+      )
+      assert(
+        abuseLimitChecks.length === 1,
+        'paid audio should still call the abuse-limit helper'
+      )
+      assert(
+        abuseLimitChecks[0].chatPaid === true,
+        'paid audio should pass donation state to abuse-limit helper'
+      )
+      assert(
+        ctx.replies.length === 1,
+        'paid audio should get normal queue progress'
+      )
+      assert(
+        ctx.replies[0].text !== 'error_transcription_user_limited',
+        'paid audio should not get rate-limit copy'
+      )
+    },
+    undefined,
+    (options) =>
+      options.chatPaid
+        ? undefined
+        : { reason: 'user_rate_limited', limit: 4, windowMs: 120_000 }
+  )
+
+  await withPatchedQueue(
+    async (createdJobs, abuseLimitChecks) => {
+      process.env.VOICY_DONATION_WALL_ENABLED = 'false'
+      const ctx = mockContext({ paid: false, chatType: 'private' })
+      await handleAudio(ctx)
+
+      assert(
+        createdJobs.length === 0,
+        'unpaid audio should still be blocked by abuse limits'
+      )
+      assert(
+        abuseLimitChecks.length === 1,
+        'unpaid audio should call the abuse-limit helper'
+      )
+      assert(
+        abuseLimitChecks[0].chatPaid === false,
+        'unpaid audio should pass unpaid state to abuse-limit helper'
+      )
+      assert(
+        ctx.replies[0].text === 'error_transcription_user_limited',
+        'unpaid audio should keep existing user limit copy'
+      )
+    },
+    undefined,
+    (options) =>
+      options.chatPaid
+        ? undefined
+        : { reason: 'user_rate_limited', limit: 4, windowMs: 120_000 }
+  )
 
   await withPatchedQueue(async (createdJobs) => {
     process.env.VOICY_DONATION_WALL_ENABLED = 'false'

--- a/scripts/transcription-abuse-limits-proof.js
+++ b/scripts/transcription-abuse-limits-proof.js
@@ -101,6 +101,27 @@ async function main() {
     'missing user id should not query user cap'
   )
 
+  const paidChatQueries = []
+  const paidChatResult = await checkTranscriptionAbuseLimits({
+    chatId: 'chat-1',
+    chatPaid: true,
+    userId: 'user-1',
+    now: new Date('2026-05-05T12:00:00.000Z'),
+    settings: {
+      chatActiveJobLimit: 2,
+      chatWindowMs: 60_000,
+      chatWindowJobLimit: 3,
+      userWindowMs: 120_000,
+      userWindowJobLimit: 4,
+    },
+    counter: counterFor([2, 3, 4], paidChatQueries),
+  })
+  assert(!paidChatResult, 'paid chats should bypass abuse limits')
+  assert(
+    paidChatQueries.length === 0,
+    'paid chats should not query abuse-limit counters'
+  )
+
   const settings = transcriptionAbuseLimitSettings({
     VOICY_TRANSCRIPTION_CHAT_ACTIVE_JOB_LIMIT: '0',
     VOICY_TRANSCRIPTION_CHAT_WINDOW_MS: 'not-a-number',

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -97,6 +97,7 @@ async function enqueueTranscription(
   }
   const abuseLimit = await checkTranscriptionAbuseLimits({
     chatId: ctx.dbchat.id,
+    chatPaid: ctx.dbchat.paid,
     userId: ctx.from?.id ? String(ctx.from.id) : undefined,
   })
   if (abuseLimit) {

--- a/src/helpers/transcriptionJobs/abuseLimits.ts
+++ b/src/helpers/transcriptionJobs/abuseLimits.ts
@@ -29,6 +29,7 @@ interface Counter {
 
 interface CheckTranscriptionAbuseLimitOptions {
   chatId: string
+  chatPaid?: boolean
   userId?: string
   now?: Date
   settings?: TranscriptionAbuseLimitSettings
@@ -64,6 +65,7 @@ export function transcriptionAbuseLimitSettings(
 
 export async function checkTranscriptionAbuseLimits({
   chatId,
+  chatPaid = false,
   userId,
   now = new Date(),
   settings = transcriptionAbuseLimitSettings(),
@@ -71,6 +73,10 @@ export async function checkTranscriptionAbuseLimits({
 }: CheckTranscriptionAbuseLimitOptions): Promise<
   TranscriptionAbuseLimitResult | undefined
 > {
+  if (chatPaid) {
+    return undefined
+  }
+
   if (settings.chatActiveJobLimit > 0) {
     const activeJobs = await counter.countDocuments({
       chatId,


### PR DESCRIPTION
## Summary
- Skip Voicy transcription abuse-limit counters when the chat is marked paid/donated.
- Preserve existing active/chat/user throttles for unpaid chats.
- Add proof coverage for direct paid-chat bypass and handler-level paid-vs-unpaid behavior.

## Behavior
Paid chats bypass the abuse-limit path entirely, including the active chat job cap, chat window limit, and user window limit, so they do not receive `error_transcription_user_limited`, `error_transcription_chat_limited`, or `error_transcription_queue_full` from this check. Donation wall and Golden Borodutch access checks still run after the bypass decision.

## Testing
- `yarn build-ts`
- `yarn test:transcription-abuse-limits`
- `yarn test:donation-wall`
- `yarn lint`

Manual QA: use Telegram with a paid/donated chat and send enough voice/audio messages to exceed the old per-user window; expect jobs to enqueue with no “You are starting transcriptions too quickly” reply. Confirm an unpaid/free path still blocks when the abuse limit is exceeded.