### PR TITLE
Bypass transcription throttles for paid requesters

### DIFF
--- a/scripts/donation-wall-proof.js
+++ b/scripts/donation-wall-proof.js
@@ -24,6 +24,7 @@ const {
 const {
   TranscriptionResultCacheModel,
 } = require('../dist/models/TranscriptionResultCache')
+const { ChatModel } = require('../dist/models/Chat')
 const abuseLimits = require('../dist/helpers/transcriptionJobs/abuseLimits')
 const goldenBorodutchAllowance = require('../dist/helpers/goldenBorodutchFreeTranscriptions')
 
@@ -126,15 +127,22 @@ async function withPatchedStripeCheckout(callback) {
   }
 }
 
-async function withPatchedQueue(callback, accessResult, abuseLimitResult) {
+async function withPatchedQueue(
+  callback,
+  accessResult,
+  abuseLimitResult,
+  requesterPaid = false
+) {
   const originalCreate = TranscriptionJobModel.create
   const originalFindJob = TranscriptionJobModel.findOne
   const originalUpdateMany = TranscriptionJobModel.updateMany
   const originalFindCache = TranscriptionResultCacheModel.findOne
+  const originalChatExists = ChatModel.exists
   const originalCheckLimits = abuseLimits.checkTranscriptionAbuseLimits
   const originalCheckAccess = goldenBorodutchAllowance.checkTranscriptionAccess
   const createdJobs = []
   const abuseLimitChecks = []
+  const paidRequesterChecks = []
 
   TranscriptionJobModel.create = async (job) => {
     const jobDoc = {
@@ -154,6 +162,12 @@ async function withPatchedQueue(callback, accessResult, abuseLimitResult) {
   TranscriptionJobModel.findOne = async () => undefined
   TranscriptionJobModel.updateMany = async () => ({ modifiedCount: 0 })
   TranscriptionResultCacheModel.findOne = async () => undefined
+  ChatModel.exists = (query) => {
+    paidRequesterChecks.push(query)
+    return {
+      exec: async () => (requesterPaid ? { _id: 'paid-requester-chat' } : null),
+    }
+  }
   abuseLimits.checkTranscriptionAbuseLimits = async (options) => {
     abuseLimitChecks.push(options)
     return typeof abuseLimitResult === 'function'
@@ -168,12 +182,13 @@ async function withPatchedQueue(callback, accessResult, abuseLimitResult) {
   }
 
   try {
-    await callback(createdJobs, abuseLimitChecks)
+    await callback(createdJobs, abuseLimitChecks, paidRequesterChecks)
   } finally {
     TranscriptionJobModel.create = originalCreate
     TranscriptionJobModel.findOne = originalFindJob
     TranscriptionJobModel.updateMany = originalUpdateMany
     TranscriptionResultCacheModel.findOne = originalFindCache
+    ChatModel.exists = originalChatExists
     abuseLimits.checkTranscriptionAbuseLimits = originalCheckLimits
     goldenBorodutchAllowance.checkTranscriptionAccess = originalCheckAccess
   }
@@ -246,6 +261,10 @@ async function main() {
         'paid audio should pass donation state to abuse-limit helper'
       )
       assert(
+        abuseLimitChecks[0].requesterPaid === true,
+        'paid chat should also pass requester donation state'
+      )
+      assert(
         ctx.replies.length === 1,
         'paid audio should get normal queue progress'
       )
@@ -259,6 +278,45 @@ async function main() {
       options.chatPaid
         ? undefined
         : { reason: 'user_rate_limited', limit: 4, windowMs: 120_000 }
+  )
+
+  await withPatchedQueue(
+    async (createdJobs, abuseLimitChecks, paidRequesterChecks) => {
+      process.env.VOICY_DONATION_WALL_ENABLED = 'false'
+      const ctx = mockContext({ paid: false, chatType: 'supergroup' })
+      await handleAudio(ctx)
+
+      assert(
+        createdJobs.length === 1,
+        'paid requester should bypass throttles in an unpaid group'
+      )
+      assert(
+        paidRequesterChecks.length === 1,
+        'unpaid group should check requester donation status'
+      )
+      assert(
+        paidRequesterChecks[0].id === '67890',
+        'requester donation lookup should use Telegram requester id'
+      )
+      assert(
+        abuseLimitChecks[0].chatPaid === false,
+        'unpaid group should pass unpaid chat state'
+      )
+      assert(
+        abuseLimitChecks[0].requesterPaid === true,
+        'paid requester should pass requester donation state'
+      )
+      assert(
+        ctx.replies[0].text !== 'error_transcription_user_limited',
+        'paid requester should not get rate-limit copy'
+      )
+    },
+    undefined,
+    (options) =>
+      options.requesterPaid
+        ? undefined
+        : { reason: 'user_rate_limited', limit: 4, windowMs: 120_000 },
+    true
   )
 
   await withPatchedQueue(
@@ -278,6 +336,10 @@ async function main() {
       assert(
         abuseLimitChecks[0].chatPaid === false,
         'unpaid audio should pass unpaid state to abuse-limit helper'
+      )
+      assert(
+        abuseLimitChecks[0].requesterPaid === false,
+        'unpaid audio should pass unpaid requester state'
       )
       assert(
         ctx.replies[0].text === 'error_transcription_user_limited',

--- a/scripts/transcription-abuse-limits-proof.js
+++ b/scripts/transcription-abuse-limits-proof.js
@@ -122,6 +122,28 @@ async function main() {
     'paid chats should not query abuse-limit counters'
   )
 
+  const paidRequesterQueries = []
+  const paidRequesterResult = await checkTranscriptionAbuseLimits({
+    chatId: 'chat-1',
+    chatPaid: false,
+    requesterPaid: true,
+    userId: 'user-1',
+    now: new Date('2026-05-05T12:00:00.000Z'),
+    settings: {
+      chatActiveJobLimit: 2,
+      chatWindowMs: 60_000,
+      chatWindowJobLimit: 3,
+      userWindowMs: 120_000,
+      userWindowJobLimit: 4,
+    },
+    counter: counterFor([2, 3, 4], paidRequesterQueries),
+  })
+  assert(!paidRequesterResult, 'paid requesters should bypass abuse limits')
+  assert(
+    paidRequesterQueries.length === 0,
+    'paid requesters should not query abuse-limit counters'
+  )
+
   const settings = transcriptionAbuseLimitSettings({
     VOICY_TRANSCRIPTION_CHAT_ACTIVE_JOB_LIMIT: '0',
     VOICY_TRANSCRIPTION_CHAT_WINDOW_MS: 'not-a-number',

--- a/src/handlers/handleAudio.ts
+++ b/src/handlers/handleAudio.ts
@@ -1,3 +1,4 @@
+import { ChatModel } from '@/models/Chat'
 import { Message } from '@grammyjs/types'
 import {
   TranscribableTelegramFile,
@@ -98,6 +99,7 @@ async function enqueueTranscription(
   const abuseLimit = await checkTranscriptionAbuseLimits({
     chatId: ctx.dbchat.id,
     chatPaid: ctx.dbchat.paid,
+    requesterPaid: await requesterHasPaidPrivateChat(ctx),
     userId: ctx.from?.id ? String(ctx.from.id) : undefined,
   })
   if (abuseLimit) {
@@ -328,6 +330,23 @@ async function enqueueTranscription(
   )
   emitTranscriptionQueued(ctx, audio.sourceType)
   return queuedJob
+}
+
+async function requesterHasPaidPrivateChat(ctx: Context) {
+  if (ctx.dbchat.paid) {
+    return true
+  }
+
+  const requesterId = ctx.from?.id ? String(ctx.from.id) : undefined
+  if (!requesterId) {
+    return false
+  }
+
+  const paidRequesterChat = await ChatModel.exists({
+    id: requesterId,
+    paid: true,
+  }).exec()
+  return Boolean(paidRequesterChat)
 }
 
 function transcriptionAccessUserId(sourceMessage: Message, ctx: Context) {

--- a/src/helpers/transcriptionJobs/abuseLimits.ts
+++ b/src/helpers/transcriptionJobs/abuseLimits.ts
@@ -30,6 +30,7 @@ interface Counter {
 interface CheckTranscriptionAbuseLimitOptions {
   chatId: string
   chatPaid?: boolean
+  requesterPaid?: boolean
   userId?: string
   now?: Date
   settings?: TranscriptionAbuseLimitSettings
@@ -66,6 +67,7 @@ export function transcriptionAbuseLimitSettings(
 export async function checkTranscriptionAbuseLimits({
   chatId,
   chatPaid = false,
+  requesterPaid = false,
   userId,
   now = new Date(),
   settings = transcriptionAbuseLimitSettings(),
@@ -73,7 +75,7 @@ export async function checkTranscriptionAbuseLimits({
 }: CheckTranscriptionAbuseLimitOptions): Promise<
   TranscriptionAbuseLimitResult | undefined
 > {
-  if (chatPaid) {
+  if (chatPaid || requesterPaid) {
     return undefined
   }
 


### PR DESCRIPTION
## Summary
- Treat a requester with a paid private Voicy chat as paid for transcription abuse-limit checks.
- Keep unpaid requesters in unpaid chats on the existing active/chat/user throttle path.
- Add proof coverage for paid requesters bypassing throttles in unpaid group chats.

## Live Root Cause
Production already had PR #191 deployed, but it only checked the current chat donation state. Nikita's private chat is paid while recent throttled jobs came from unpaid group chat `-1003707712608`, so the group still hit user-window throttles.

## Testing
- `yarn build-ts`
- `yarn test:transcription-abuse-limits`
- `yarn test:donation-wall`
- `yarn lint`