### PR TITLE
VOI-67: Start GPU transcription as soon as each job download completes

### DIFF
--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -880,6 +880,7 @@ export async function processAvailableJobs(
     const ready = await downloadJob(api, config, job, logger)
     if (ready) {
       readyQueue.push(ready)
+      fillTranscriptions()
     }
   }
 


### PR DESCRIPTION
## Problem

Currently, the worker downloads jobs in parallel (up to `downloadConcurrency`) and stores completed downloads in a `readyQueue`. Transcription only starts at the top of the next poll loop iteration via `fillTranscriptions()`. This means the GPU can sit idle while the remaining downloads in the batch finish.

## Solution

When each individual download completes, immediately call `fillTranscriptions()` to begin transcription as soon as the file is available — while still respecting the `transcriptionConcurrency` limit. Jobs that arrive when the GPU is already at capacity remain in `readyQueue` as before.

## Changes

- `src/workerClient/runWindowsWorker.ts`: one-line change in `startDownload()\n
## Risk / Race Conditions

- The change is purely scheduling: the same `fillTranscriptions()` function is called, just earlier. It still checks `transcriptions.size < config.transcriptionConcurrency` before starting any work.
- The existing `waitForActiveWork()` / loop logic handles the case where a download completes mid-loop and adds to `readyQueue" while a transcription is already running.

## Testing

- `yarn test:worker-client` passes (includes the scheduling proof that validates `small-job` transcribes before `slow-job` when `downloadConcurrency=2` and `transcriptionConcurrency=1`).

Fixes VOI-67