### PR TITLE
VOI-68: Harden worker stale job handling

### DIFF
--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -485,6 +485,213 @@ function createRestartProofServer() {
   return { server, state }
 }
 
+function createStaleWorkerProofServer(mode) {
+  const ids =
+    mode === 'start'
+      ? ['stale-start-job', 'later-job']
+      : [`stale-${mode}-job`]
+  const queue = [...ids]
+  const state = {
+    claimed: [],
+    downloaded: [],
+    transcribeAttempts: [],
+    results: [],
+    failures: [],
+    heartbeats: 0,
+  }
+
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url, 'http://127.0.0.1')
+    if (
+      !url.pathname.startsWith('/audio/') &&
+      request.headers.authorization !== 'Bearer proof-worker-token'
+    ) {
+      response.writeHead(401, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify({ error: 'invalid_worker_token' }))
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/claim-download'
+    ) {
+      const id = queue.shift()
+      if (!id) {
+        response.writeHead(204)
+        response.end()
+        return
+      }
+      state.claimed.push(id)
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id,
+            status: 'downloading',
+            chatId: 'stale-chat',
+            sourceKind: 'voice',
+            fileSize: 17,
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    const sourceMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/source$/
+    )
+    if (request.method === 'GET' && sourceMatch) {
+      const id = sourceMatch[1]
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          source: {
+            sourceUrl: `http://127.0.0.1:${
+              server.address().port
+            }/audio/${id}.ogg`,
+            sourceKind: 'voice',
+            mimeType: 'audio/ogg',
+          },
+        })
+      )
+      return
+    }
+
+    const audioMatch = url.pathname.match(/^\/audio\/([^/]+)\.ogg$/)
+    if (request.method === 'GET' && audioMatch) {
+      response.writeHead(200, { 'Content-Type': 'audio/ogg' })
+      response.end(Buffer.from(`${audioMatch[1]} audio bytes`))
+      return
+    }
+
+    const downloadedMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/downloaded$/
+    )
+    if (request.method === 'POST' && downloadedMatch) {
+      const id = downloadedMatch[1]
+      await readJson(request)
+      state.downloaded.push(id)
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id,
+            status: 'ready',
+            chatId: 'stale-chat',
+            sourceKind: 'voice',
+            fileSize: 17,
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    const transcribeMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/transcribe$/
+    )
+    if (request.method === 'POST' && transcribeMatch) {
+      const id = transcribeMatch[1]
+      state.transcribeAttempts.push(id)
+      if (mode === 'start' && id === 'stale-start-job') {
+        response.writeHead(404, { 'Content-Type': 'application/json' })
+        response.end(JSON.stringify({ error: 'job_not_found' }))
+        return
+      }
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id,
+            status: 'transcribing',
+            chatId: 'stale-chat',
+            sourceKind: 'voice',
+            fileSize: 17,
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    const heartbeatMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/heartbeat$/
+    )
+    if (request.method === 'POST' && heartbeatMatch) {
+      state.heartbeats += 1
+      if (mode === 'heartbeat') {
+        response.writeHead(404, { 'Content-Type': 'application/json' })
+        response.end(JSON.stringify({ error: 'job_not_found' }))
+        return
+      }
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify({ job: { id: heartbeatMatch[1] } }))
+      return
+    }
+
+    const resultMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/result$/
+    )
+    if (request.method === 'POST' && resultMatch) {
+      const body = await readJson(request)
+      if (mode === 'result') {
+        response.writeHead(404, { 'Content-Type': 'application/json' })
+        response.end(JSON.stringify({ error: 'job_not_found' }))
+        return
+      }
+      state.results.push({ id: resultMatch[1], body })
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({ job: { id: resultMatch[1], status: 'completed' } })
+      )
+      return
+    }
+
+    const failureMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/failure$/
+    )
+    if (request.method === 'POST' && failureMatch) {
+      const body = await readJson(request)
+      if (mode === 'failure') {
+        response.writeHead(404, { 'Content-Type': 'application/json' })
+        response.end(JSON.stringify({ error: 'job_not_found' }))
+        return
+      }
+      state.failures.push({ id: failureMatch[1], body })
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({ job: { id: failureMatch[1], status: 'failed' } })
+      )
+      return
+    }
+
+    if (request.method === 'POST' && url.pathname === '/worker/v1/jobs/claim') {
+      response.writeHead(204)
+      response.end()
+      return
+    }
+
+    response.writeHead(404, { 'Content-Type': 'application/json' })
+    response.end(JSON.stringify({ error: 'not_found' }))
+  })
+
+  return { server, state }
+}
+
+function staleWorkerLogs(logLines, phase, action) {
+  return logLines.filter(
+    (line) =>
+      line.includes('Worker stale job ignored') &&
+      line.includes(`phase="${phase}"`) &&
+      line.includes(`action="${action}"`) &&
+      line.includes('backendError="job_not_found"')
+  )
+}
+
 async function main() {
   const { server, state } = createProofServer()
   await listen(server)
@@ -929,6 +1136,239 @@ async function main() {
     )
   } finally {
     await close(failureProof.server)
+  }
+
+  const staleStartProof = createStaleWorkerProofServer('start')
+  await listen(staleStartProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      staleStartProof.server.address().port
+    }/worker/v1`
+    const staleStartLogLines = []
+    const processed = await processAvailableJobs(
+      loadConfig({
+        VOICY_WORKER_API_URL: baseUrl,
+        VOICY_WORKER_TOKEN: 'proof-worker-token',
+        VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+        VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+          'scripts/fake-transcriber.js',
+          '{input}',
+          '{output}',
+        ]),
+        VOICY_WORKER_WORK_DIR: path.join(
+          os.tmpdir(),
+          `voicy-worker-stale-start-proof-${process.pid}`
+        ),
+        VOICY_WORKER_DOWNLOAD_CONCURRENCY: '1',
+        VOICY_WORKER_TRANSCRIPTION_CONCURRENCY: '1',
+      }),
+      {
+        info: (message) => staleStartLogLines.push(message),
+        warn: (message) => staleStartLogLines.push(message),
+        error: (message) => staleStartLogLines.push(message),
+      }
+    )
+
+    assert(
+      processed === 2,
+      'stale start proof should still count both claimed jobs'
+    )
+    assert(
+      staleStartProof.state.results.length === 1 &&
+        staleStartProof.state.results[0].id === 'later-job',
+      'worker should keep processing later jobs after stale start'
+    )
+    assert(
+      staleStartProof.state.failures.length === 0,
+      'stale start should not report job failure'
+    )
+    assert(
+      staleWorkerLogs(
+        staleStartLogLines,
+        'transcription',
+        'start_transcription'
+      ).length === 1,
+      'stale start should log one structured stale-job line'
+    )
+  } finally {
+    await close(staleStartProof.server)
+  }
+
+  const staleResultProof = createStaleWorkerProofServer('result')
+  await listen(staleResultProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      staleResultProof.server.address().port
+    }/worker/v1`
+    const staleResultLogLines = []
+    const staleTranscriptText =
+      'stale result transcript 123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabc'
+    const previousFakeTranscriptText = process.env.VOICY_FAKE_TRANSCRIPT_TEXT
+    process.env.VOICY_FAKE_TRANSCRIPT_TEXT = staleTranscriptText
+    try {
+      const processed = await processNextJob(
+        loadConfig({
+          VOICY_WORKER_API_URL: baseUrl,
+          VOICY_WORKER_TOKEN: 'proof-worker-token',
+          VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+          VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+            'scripts/fake-transcriber.js',
+            '{input}',
+            '{output}',
+          ]),
+          VOICY_WORKER_WORK_DIR: path.join(
+            os.tmpdir(),
+            `voicy-worker-stale-result-proof-${process.pid}`
+          ),
+        }),
+        {
+          info: (message) => staleResultLogLines.push(message),
+          warn: (message) => staleResultLogLines.push(message),
+          error: (message) => staleResultLogLines.push(message),
+        }
+      )
+      assert(processed, 'stale result proof should claim a job')
+    } finally {
+      if (previousFakeTranscriptText === undefined) {
+        delete process.env.VOICY_FAKE_TRANSCRIPT_TEXT
+      } else {
+        process.env.VOICY_FAKE_TRANSCRIPT_TEXT = previousFakeTranscriptText
+      }
+    }
+
+    assert(
+      staleResultProof.state.failures.length === 0,
+      'stale result should not report job failure'
+    )
+    assert(
+      staleWorkerLogs(
+        staleResultLogLines,
+        'result_upload',
+        'upload_result'
+      ).length === 1,
+      'stale result should log one structured stale-job line'
+    )
+    assert(
+      staleResultLogLines.every(
+        (line) => !line.includes(staleTranscriptText)
+      ),
+      'stale result logs should not include raw transcript text'
+    )
+  } finally {
+    await close(staleResultProof.server)
+  }
+
+  const staleHeartbeatProof = createStaleWorkerProofServer('heartbeat')
+  await listen(staleHeartbeatProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      staleHeartbeatProof.server.address().port
+    }/worker/v1`
+    const staleHeartbeatLogLines = []
+    const processed = await processNextJob(
+      loadConfig({
+        VOICY_WORKER_API_URL: baseUrl,
+        VOICY_WORKER_TOKEN: 'proof-worker-token',
+        VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+        VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+          '-e',
+          "setTimeout(() => process.stdout.write(JSON.stringify({ text: 'heartbeat stale transcript', parts: [], language: 'en' })), 50)",
+        ]),
+        VOICY_WORKER_WORK_DIR: path.join(
+          os.tmpdir(),
+          `voicy-worker-stale-heartbeat-proof-${process.pid}`
+        ),
+        VOICY_WORKER_HEARTBEAT_INTERVAL_MS: '1',
+      }),
+      {
+        info: (message) => staleHeartbeatLogLines.push(message),
+        warn: (message) => staleHeartbeatLogLines.push(message),
+        error: (message) => staleHeartbeatLogLines.push(message),
+      }
+    )
+
+    assert(processed, 'stale heartbeat proof should claim a job')
+    assert(
+      staleHeartbeatProof.state.heartbeats >= 1,
+      'stale heartbeat proof should exercise the heartbeat endpoint'
+    )
+    assert(
+      staleHeartbeatProof.state.results.length === 0,
+      'stale heartbeat should drop the finished local result'
+    )
+    assert(
+      staleHeartbeatProof.state.failures.length === 0,
+      'stale heartbeat should not report job failure'
+    )
+    assert(
+      staleWorkerLogs(
+        staleHeartbeatLogLines,
+        'heartbeat',
+        'heartbeat'
+      ).length === 1,
+      'stale heartbeat should log one structured stale-job line'
+    )
+  } finally {
+    await close(staleHeartbeatProof.server)
+  }
+
+  const staleFailureProof = createStaleWorkerProofServer('failure')
+  await listen(staleFailureProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      staleFailureProof.server.address().port
+    }/worker/v1`
+    const staleFailureLogLines = []
+    const processed = await processNextJob(
+      loadConfig({
+        VOICY_WORKER_API_URL: baseUrl,
+        VOICY_WORKER_TOKEN: 'proof-worker-token',
+        VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+        VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+          '-e',
+          'process.stdout.write("PRIVATE STALE FAILURE TRANSCRIPT"); process.exit(3)',
+        ]),
+        VOICY_WORKER_WORK_DIR: path.join(
+          os.tmpdir(),
+          `voicy-worker-stale-failure-proof-${process.pid}`
+        ),
+      }),
+      {
+        info: (message) => staleFailureLogLines.push(message),
+        warn: (message) => staleFailureLogLines.push(message),
+        error: (message) => staleFailureLogLines.push(message),
+      }
+    )
+
+    assert(processed, 'stale failure proof should claim a job')
+    assert(
+      staleFailureProof.state.results.length === 0,
+      'failed stale job should not submit result'
+    )
+    assert(
+      staleFailureProof.state.failures.length === 0,
+      'stale failure report should not be accepted as a normal failure'
+    )
+    assert(
+      staleWorkerLogs(
+        staleFailureLogLines,
+        'failure_report',
+        'report_failure'
+      ).length === 1,
+      'stale failure report should log one structured stale-job line'
+    )
+    assert(
+      staleFailureLogLines.every(
+        (line) => !line.includes('PRIVATE STALE FAILURE TRANSCRIPT')
+      ),
+      'stale failure logs should not include raw transcript output'
+    )
+  } finally {
+    await close(staleFailureProof.server)
   }
 
   const schedulingProof = createSchedulingProofServer()

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -109,6 +109,11 @@ interface ResolvedSource {
   localPath?: string
 }
 
+interface HeartbeatHandle {
+  isStale: () => boolean
+  stop: () => void
+}
+
 const consoleLogger: Logger = {
   info: (message) => console.log(message),
   warn: (message) => console.warn(message),
@@ -116,6 +121,13 @@ const consoleLogger: Logger = {
 }
 
 type LogValue = string | number | boolean | undefined
+
+const staleWorkerJobErrorCodes = new Set([
+  'job_not_found',
+  'job_not_owned',
+  'job_not_active',
+  'job_cancelled',
+])
 
 function formatLogValue(value: LogValue) {
   if (typeof value === 'string') {
@@ -138,6 +150,41 @@ function logWorkerActivity(
 ) {
   const formattedContext = formatLogContext(context)
   logger.info(formattedContext ? `${message} ${formattedContext}` : message)
+}
+
+function backendErrorCode(error: unknown) {
+  if (!axios.isAxiosError(error)) {
+    return undefined
+  }
+  const data = error.response?.data
+  if (!data || typeof data !== 'object') {
+    return undefined
+  }
+  const code = (data as { error?: unknown }).error
+  return typeof code === 'string' ? code : undefined
+}
+
+function isStaleWorkerJobError(error: unknown) {
+  if (!axios.isAxiosError(error) || error.response?.status !== 404) {
+    return false
+  }
+  const code = backendErrorCode(error)
+  return code ? staleWorkerJobErrorCodes.has(code) : false
+}
+
+function logStaleWorkerJob(
+  logger: Logger,
+  job: WorkerJob,
+  phase: string,
+  action: string,
+  error: unknown
+) {
+  logWorkerActivity(logger, 'Worker stale job ignored', {
+    ...jobLogContext(job),
+    phase,
+    action,
+    backendError: backendErrorCode(error) || 'unknown',
+  })
 }
 
 function jobLogContext(job: WorkerJob): Record<string, LogValue> {
@@ -715,6 +762,7 @@ async function transcribeJob(
 async function failJob(
   api: AxiosInstance,
   jobId: string,
+  job: WorkerJob,
   error: unknown,
   logger: Logger
 ) {
@@ -723,26 +771,51 @@ async function failJob(
     error instanceof Error ? error.message : String(error)
   )
   logger.warn(`Reporting job ${jobId} failure: ${message}`)
-  await api.post(`/jobs/${jobId}/failure`, { error: message, retryable })
+  try {
+    await api.post(`/jobs/${jobId}/failure`, { error: message, retryable })
+  } catch (failureError) {
+    if (isStaleWorkerJobError(failureError)) {
+      logStaleWorkerJob(
+        logger,
+        job,
+        'failure_report',
+        'report_failure',
+        failureError
+      )
+      return
+    }
+    throw failureError
+  }
 }
 
 function startHeartbeat(
   api: AxiosInstance,
-  jobId: string,
+  job: WorkerJob,
   intervalMs: number,
   logger: Logger
-) {
+): HeartbeatHandle | undefined {
   if (intervalMs <= 0) {
     return undefined
   }
-  return setInterval(() => {
-    api.post(`/jobs/${jobId}/heartbeat`).catch((error) => {
+  let stale = false
+  const timer = setInterval(() => {
+    api.post(`/jobs/${job.id}/heartbeat`).catch((error) => {
+      if (isStaleWorkerJobError(error)) {
+        stale = true
+        logStaleWorkerJob(logger, job, 'heartbeat', 'heartbeat', error)
+        clearInterval(timer)
+        return
+      }
       const message = redactSensitiveText(
         error instanceof Error ? error.message : String(error)
       )
-      logger.warn(`Heartbeat failed for job ${jobId}: ${message}`)
+      logger.warn(`Heartbeat failed for job ${job.id}: ${message}`)
     })
   }, intervalMs)
+  return {
+    isStale: () => stale,
+    stop: () => clearInterval(timer),
+  }
 }
 
 export async function processNextJob(
@@ -765,17 +838,39 @@ async function downloadJob(
     'Worker media download job claimed',
     jobLogContext(job)
   )
-  const heartbeat = startHeartbeat(
-    api,
-    job.id,
-    config.heartbeatIntervalMs,
-    logger
-  )
+  const heartbeat = startHeartbeat(api, job, config.heartbeatIntervalMs, logger)
 
   try {
-    const source = await getSource(api, job.id)
+    let source: WorkerSource
+    try {
+      source = await getSource(api, job.id)
+    } catch (error) {
+      if (isStaleWorkerJobError(error)) {
+        logStaleWorkerJob(logger, job, 'download', 'get_source', error)
+        return undefined
+      }
+      throw error
+    }
     const inputPath = await downloadSource(config, job, source)
-    const readyJob = await markDownloaded(api, job.id, inputPath)
+    if (heartbeat?.isStale()) {
+      logWorkerActivity(logger, 'Worker media download result dropped', {
+        ...jobLogContext(job),
+        phase: 'mark_downloaded',
+        action: 'drop_after_stale_heartbeat',
+        inputFile: path.basename(inputPath),
+      })
+      return undefined
+    }
+    let readyJob: WorkerJob
+    try {
+      readyJob = await markDownloaded(api, job.id, inputPath)
+    } catch (error) {
+      if (isStaleWorkerJobError(error)) {
+        logStaleWorkerJob(logger, job, 'download', 'mark_downloaded', error)
+        return undefined
+      }
+      throw error
+    }
     logWorkerActivity(logger, 'Worker media download completed', {
       ...jobLogContext(readyJob),
       elapsedMs: Date.now() - startedAt,
@@ -790,11 +885,19 @@ async function downloadJob(
       elapsedMs: Date.now() - startedAt,
       retryable,
     })
-    await failJob(api, job.id, error, logger)
+    if (heartbeat?.isStale()) {
+      logWorkerActivity(logger, 'Worker media download failure dropped', {
+        ...jobLogContext(job),
+        phase: 'failure_report',
+        action: 'drop_after_stale_heartbeat',
+      })
+      return undefined
+    }
+    await failJob(api, job.id, job, error, logger)
     return undefined
   } finally {
     if (heartbeat) {
-      clearInterval(heartbeat)
+      heartbeat.stop()
     }
   }
 }
@@ -806,21 +909,31 @@ async function transcribeDownloadedJob(
   logger: Logger
 ) {
   const startedAt = Date.now()
-  const job = ['processing', 'transcribing'].includes(downloaded.job.status)
-    ? downloaded.job
-    : await startTranscription(api, downloaded.job.id)
+  let job: WorkerJob
+  try {
+    job = ['processing', 'transcribing'].includes(downloaded.job.status)
+      ? downloaded.job
+      : await startTranscription(api, downloaded.job.id)
+  } catch (error) {
+    if (isStaleWorkerJobError(error)) {
+      logStaleWorkerJob(
+        logger,
+        downloaded.job,
+        'transcription',
+        'start_transcription',
+        error
+      )
+      return
+    }
+    throw error
+  }
   logWorkerActivity(logger, 'Worker transcription job started', {
     ...jobLogContext(job),
     engine: config.engine,
     model: config.model,
     inputFile: path.basename(downloaded.inputPath),
   })
-  const heartbeat = startHeartbeat(
-    api,
-    job.id,
-    config.heartbeatIntervalMs,
-    logger
-  )
+  const heartbeat = startHeartbeat(api, job, config.heartbeatIntervalMs, logger)
 
   try {
     const result = await transcribeJob(
@@ -837,7 +950,24 @@ async function transcribeDownloadedJob(
         Date.now() - startedAt
       ),
     })
-    await api.post(`/jobs/${job.id}/result`, result)
+    if (heartbeat?.isStale()) {
+      logWorkerActivity(logger, 'Worker transcription result dropped', {
+        ...jobLogContext(job),
+        phase: 'result_upload',
+        action: 'drop_after_stale_heartbeat',
+        textChars: result.text.length,
+      })
+      return
+    }
+    try {
+      await api.post(`/jobs/${job.id}/result`, result)
+    } catch (error) {
+      if (isStaleWorkerJobError(error)) {
+        logStaleWorkerJob(logger, job, 'result_upload', 'upload_result', error)
+        return
+      }
+      throw error
+    }
     logWorkerActivity(logger, 'Worker transcription job completed', {
       ...transcriptionResultLogContext(
         job,
@@ -857,10 +987,18 @@ async function transcribeDownloadedJob(
       elapsedMs: Date.now() - startedAt,
       retryable,
     })
-    await failJob(api, job.id, error, logger)
+    if (heartbeat?.isStale()) {
+      logWorkerActivity(logger, 'Worker transcription failure dropped', {
+        ...jobLogContext(job),
+        phase: 'failure_report',
+        action: 'drop_after_stale_heartbeat',
+      })
+      return
+    }
+    await failJob(api, job.id, job, error, logger)
   } finally {
     if (heartbeat) {
-      clearInterval(heartbeat)
+      heartbeat.stop()
     }
   }
 }


### PR DESCRIPTION
## Summary
- Classify worker API 404 stale-job responses (`job_not_found` plus future ownership/state codes) separately from retryable network/server errors.
- Stop stale local work items on source/downloaded/start/heartbeat/result/failure paths without reporting another failure or crashing the worker loop.
- Add worker-client proof coverage for stale start, result upload, heartbeat, and failure-report responses, including queue continuation and sanitized logging.

## Validation
- `yarn test:worker-client` - passed
- `yarn build-ts` - passed
- `yarn lint` - passed

Manual QA: not required for this change; the behavior is covered by local HTTP proof servers simulating the worker API stale ownership races. Windows-host smoke was not run because no staged Windows worker deployment was needed for the client-side classification change.