### PR TITLE
Guard oversized worker transcript results

### DIFF
--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -1373,6 +1373,187 @@ async function main() {
     await close(largeStdoutFallbackProof.server)
   }
 
+  const largeResultTextProof = createProofServer()
+  await listen(largeResultTextProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      largeResultTextProof.server.address().port
+    }/worker/v1`
+    const config = loadConfig({
+      VOICY_WORKER_API_URL: baseUrl,
+      VOICY_WORKER_TOKEN: 'proof-worker-token',
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        '-e',
+        [
+          "const fs = require('fs')",
+          "fs.writeFileSync(process.argv[2], JSON.stringify({ text: 't'.repeat(100001), parts: [], language: 'en', duration: 2 }))",
+        ].join('; '),
+        '{input}',
+        '{output}',
+      ]),
+      VOICY_WORKER_WORK_DIR: path.join(
+        os.tmpdir(),
+        `voicy-worker-large-result-text-proof-${process.pid}`
+      ),
+      VOICY_WORKER_TELEGRAM_API_URL: `http://127.0.0.1:${
+        largeResultTextProof.server.address().port
+      }`,
+      VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
+    })
+
+    const processed = await processNextJob(config, {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    })
+
+    assert(processed, 'large result text proof should claim the job')
+    assert(
+      !largeResultTextProof.state.result,
+      'oversized result text should not be uploaded'
+    )
+    assert(
+      largeResultTextProof.state.failure,
+      'oversized result text should report a controlled failure'
+    )
+    assert(
+      largeResultTextProof.state.failure.retryable === false,
+      'oversized result text should be a non-retryable worker config failure'
+    )
+    assert(
+      largeResultTextProof.state.failure.error.includes(
+        'Transcription result text is too large to upload safely'
+      ) &&
+        largeResultTextProof.state.failure.error.includes('textChars=100001'),
+      'oversized result text failure should explain the text limit'
+    )
+  } finally {
+    await close(largeResultTextProof.server)
+  }
+
+  const tooManyResultPartsProof = createProofServer()
+  await listen(tooManyResultPartsProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      tooManyResultPartsProof.server.address().port
+    }/worker/v1`
+    const config = loadConfig({
+      VOICY_WORKER_API_URL: baseUrl,
+      VOICY_WORKER_TOKEN: 'proof-worker-token',
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        '-e',
+        [
+          "const fs = require('fs')",
+          "fs.writeFileSync(process.argv[2], JSON.stringify({ text: 'too many parts transcript', parts: Array.from({ length: 5001 }, () => ({ text: 'p' })), language: 'en', duration: 2 }))",
+        ].join('; '),
+        '{input}',
+        '{output}',
+      ]),
+      VOICY_WORKER_WORK_DIR: path.join(
+        os.tmpdir(),
+        `voicy-worker-too-many-result-parts-proof-${process.pid}`
+      ),
+      VOICY_WORKER_TELEGRAM_API_URL: `http://127.0.0.1:${
+        tooManyResultPartsProof.server.address().port
+      }`,
+      VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
+    })
+
+    const processed = await processNextJob(config, {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    })
+
+    assert(processed, 'too many result parts proof should claim the job')
+    assert(
+      !tooManyResultPartsProof.state.result,
+      'too many result parts should not be uploaded'
+    )
+    assert(
+      tooManyResultPartsProof.state.failure,
+      'too many result parts should report a controlled failure'
+    )
+    assert(
+      tooManyResultPartsProof.state.failure.retryable === false,
+      'too many result parts should be a non-retryable worker config failure'
+    )
+    assert(
+      tooManyResultPartsProof.state.failure.error.includes(
+        'Transcription result has too many parts to upload safely'
+      ) && tooManyResultPartsProof.state.failure.error.includes('parts=5001'),
+      'too many result parts failure should explain the parts limit'
+    )
+  } finally {
+    await close(tooManyResultPartsProof.server)
+  }
+
+  const oversizedOutputFileProof = createProofServer()
+  await listen(oversizedOutputFileProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      oversizedOutputFileProof.server.address().port
+    }/worker/v1`
+    const config = loadConfig({
+      VOICY_WORKER_API_URL: baseUrl,
+      VOICY_WORKER_TOKEN: 'proof-worker-token',
+      VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+      VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+        '-e',
+        [
+          "const fs = require('fs')",
+          "fs.writeFileSync(process.argv[2], JSON.stringify({ text: 'oversized output file transcript', parts: [{ text: 'p'.repeat(2 * 1024 * 1024) }], language: 'en', duration: 2 }))",
+        ].join('; '),
+        '{input}',
+        '{output}',
+      ]),
+      VOICY_WORKER_WORK_DIR: path.join(
+        os.tmpdir(),
+        `voicy-worker-oversized-output-file-proof-${process.pid}`
+      ),
+      VOICY_WORKER_TELEGRAM_API_URL: `http://127.0.0.1:${
+        oversizedOutputFileProof.server.address().port
+      }`,
+      VOICY_WORKER_TELEGRAM_BOT_TOKEN: 'proof-telegram-token',
+    })
+
+    const processed = await processNextJob(config, {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    })
+
+    assert(processed, 'oversized output file proof should claim the job')
+    assert(
+      !oversizedOutputFileProof.state.result,
+      'oversized output file should not be uploaded'
+    )
+    assert(
+      oversizedOutputFileProof.state.failure,
+      'oversized output file should report a controlled failure'
+    )
+    assert(
+      oversizedOutputFileProof.state.failure.retryable === false,
+      'oversized output file should be a non-retryable worker config failure'
+    )
+    assert(
+      oversizedOutputFileProof.state.failure.error.includes(
+        'Transcription output file is too large to parse safely'
+      ) &&
+        oversizedOutputFileProof.state.failure.error.includes(
+          'maxBytes=1048576'
+        ),
+      'oversized output file failure should explain the byte limit'
+    )
+  } finally {
+    await close(oversizedOutputFileProof.server)
+  }
+
   const failureProof = createProofServer()
   await listen(failureProof.server)
 

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -1,7 +1,6 @@
 import * as path from 'path'
 import { Readable } from 'stream'
 import { URL } from 'url'
-import { constants as bufferConstants } from 'buffer'
 import { copyFile, mkdir, readFile, stat, unlink } from 'fs/promises'
 import { createWriteStream } from 'fs'
 import { pipeline } from 'stream'
@@ -19,7 +18,9 @@ const DEFAULT_RESTART_DELAY_MS = 10000
 const DEFAULT_WORK_DIR = path.join(process.cwd(), 'tmp', 'voicy-worker')
 const DEFAULT_WORKER_MODEL = 'large-v3'
 const COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES = 1024 * 1024
-const MAX_TRANSCRIPTION_OUTPUT_BYTES = bufferConstants.MAX_STRING_LENGTH - 1024
+const MAX_TRANSCRIPTION_OUTPUT_BYTES = COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES
+const MAX_TRANSCRIPTION_RESULT_TEXT_CHARS = 100000
+const MAX_TRANSCRIPTION_RESULT_PARTS = 5000
 const TRANSCRIPTION_RESULT_LOG_CHARS = 2000
 
 type WorkerQueueBucket = 'oldest' | 'newest'
@@ -778,6 +779,26 @@ function normalizeTranscriptionOutput(
   }
 }
 
+function assertSafeTranscriptionOutput(
+  result: ReturnType<typeof normalizeTranscriptionOutput>
+) {
+  if (result.text.length > MAX_TRANSCRIPTION_RESULT_TEXT_CHARS) {
+    throw new WorkerClientError(
+      `Transcription result text is too large to upload safely; textChars=${result.text.length}; maxTextChars=${MAX_TRANSCRIPTION_RESULT_TEXT_CHARS}`,
+      false
+    )
+  }
+  if (
+    Array.isArray(result.parts) &&
+    result.parts.length > MAX_TRANSCRIPTION_RESULT_PARTS
+  ) {
+    throw new WorkerClientError(
+      `Transcription result has too many parts to upload safely; parts=${result.parts.length}; maxParts=${MAX_TRANSCRIPTION_RESULT_PARTS}`,
+      false
+    )
+  }
+}
+
 async function readTranscriptionOutput(
   commandResult: RunCommandResult,
   outputPath: string,
@@ -792,7 +813,7 @@ async function readTranscriptionOutput(
   if (outputStat) {
     if (outputStat.size > MAX_TRANSCRIPTION_OUTPUT_BYTES) {
       throw new WorkerClientError(
-        `Transcription output file is too large to parse safely; outputBytes=${outputStat.size}`,
+        `Transcription output file is too large to parse safely; outputBytes=${outputStat.size}; maxBytes=${MAX_TRANSCRIPTION_OUTPUT_BYTES}`,
         false
       )
     }
@@ -809,6 +830,7 @@ async function readTranscriptionOutput(
     outputSource = 'stdout'
   }
   const result = normalizeTranscriptionOutput(rawOutput, config, job, inputPath)
+  assertSafeTranscriptionOutput(result)
   logWorkerActivity(logger, 'Worker transcription command completed', {
     jobId: job.id,
     engine: config.engine,


### PR DESCRIPTION
## Summary
- cap worker transcript output files at 1 MiB before reading them into strings
- reject oversized final transcript text and result part lists locally before upload/request serialization
- add worker-client proofs for oversized result text, too many result parts, and oversized transcript output files

## Validation
- `yarn install --frozen-lockfile`
- Reproduction before fix: `yarn build-ts && yarn test:worker-client` failed with `oversized result text should not be uploaded`
- `npx prettier --write scripts/worker-client-proof.js && yarn build-ts && yarn test:worker-client && yarn lint && git diff --check`

Blocked/limited:
- `yarn test:worker-api` was attempted but exits immediately because `MONGO` is not configured in this workspace.

## Manual QA / Deployment Handoff
Manual browser or Telegram Web QA is not required for this code path; the change is isolated to the Windows worker's transcriber output/result handling.

Production follow-up after merge is required: update the Windows worker checkout/install on `backm@borodutch-pc`, restart scheduled task `VoicyWorker4070Ti`, and confirm `C:\voicy-worker\logs\worker.log` shows the new worker start plus successful post-restart job processing.
