### PR TITLE
Fix ready backlog recovery fairness

### DIFF
--- a/docs/windows-worker-client.md
+++ b/docs/windows-worker-client.md
@@ -394,10 +394,13 @@ file size, language hint, and attempt count, but never transcript text or source
 URLs.
 
 On restart, the worker calls `POST /jobs/claim-ready` to recover ready local
-files already owned by the same worker. The backend also lets that endpoint
-reclaim same-worker `transcribing`/legacy `processing` jobs with a stale
-heartbeat and a stored `localSourcePath`; the default stale cutoff is 15 minutes
-and can be adjusted with `VOICY_WORKER_STALE_ACTIVE_JOB_MS`.
+files already owned by the same worker. Recovery claims alternate between the
+oldest and newest ready jobs, so a newly downloaded short voice can run between
+older local backlog items instead of waiting for every stale ready job first. The
+backend also lets that endpoint reclaim same-worker `transcribing`/legacy
+`processing` jobs with a stale heartbeat and a stored `localSourcePath`; the
+default stale cutoff is 15 minutes and can be adjusted with
+`VOICY_WORKER_STALE_ACTIVE_JOB_MS`.
 
 `VOICY_WORKER_TRANSCRIBE_ARGS_JSON` must be a JSON array of argument strings.
 Each argument may contain `{input}`, `{output}`, `{language}`, and `{model}`.
@@ -476,7 +479,9 @@ checks the no-work polling path, checks retryable command failure reporting, and
 proves a smaller ready download can transcribe before a slower earlier download.
 It also covers fair backlog recovery: after download claims are exhausted while
 older ready work remains, a fresh newest-bucket job is claimed and transcribed
-before the older ready backlog fully drains.
+before the older ready backlog fully drains. The proof also covers already-ready
+backlog recovery, where `claim-ready` alternates a fresh newest-bucket ready job
+between older ready jobs from the same worker.
 
 `yarn test:worker-e2e` uses the real Express worker API, local Mongo, a queued
 `TranscriptionJob`, a local sample-audio HTTP server, and the worker client. It

--- a/docs/worker-api.md
+++ b/docs/worker-api.md
@@ -88,8 +88,8 @@ after the local media file is fully available.
 
 ### `POST /jobs/claim-ready`
 
-Claims the oldest ready local file owned by the authenticated worker and marks
-it `transcribing`. This endpoint is available for split downloader/transcriber
+Claims a ready local file owned by the authenticated worker and marks it
+`transcribing`. This endpoint is available for split downloader/transcriber
 clients and for worker restart recovery. The request body may include
 `{"bucket":"oldest"}` or `{"bucket":"newest"}` to choose the sort direction.
 The endpoint can also reclaim same-worker `transcribing` or legacy `processing`
@@ -100,7 +100,9 @@ cutoff is 15 minutes and can be adjusted with
 
 The bundled worker normally calls `POST /jobs/:id/transcribe` for the job it
 just downloaded, but it also polls `claim-ready` when a transcription slot is
-free so ready jobs from an older local run are not stranded.
+free so ready jobs from an older local run are not stranded. Recovery claims
+alternate between `oldest` and `newest` buckets so fresh ready jobs do not wait
+for the whole stale ready backlog to drain.
 
 ### `POST /jobs/claim`
 

--- a/scripts/worker-client-proof.js
+++ b/scripts/worker-client-proof.js
@@ -616,6 +616,126 @@ function createFairBacklogRecoveryProofServer() {
   return { server, state }
 }
 
+function createReadyBacklogRecoveryProofServer() {
+  const oldQueue = ['old-ready-1', 'old-ready-2']
+  const newestQueue = ['fresh-ready-job']
+  const workDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `voicy-worker-ready-recovery-source-${process.pid}-`)
+  )
+  const state = {
+    readyClaims: [],
+    results: [],
+  }
+
+  for (const id of [...oldQueue, ...newestQueue]) {
+    fs.writeFileSync(path.join(workDir, `${id}.ogg`), `${id} audio bytes`)
+  }
+
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url, 'http://127.0.0.1')
+    if (request.headers.authorization !== 'Bearer proof-worker-token') {
+      response.writeHead(401, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify({ error: 'invalid_worker_token' }))
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/claim-download'
+    ) {
+      await readJson(request)
+      response.writeHead(204)
+      response.end()
+      return
+    }
+
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/worker/v1/jobs/claim-ready'
+    ) {
+      const body = await readJson(request)
+      const bucket = body.bucket || 'oldest'
+      const queue = bucket === 'newest' ? newestQueue : oldQueue
+      const id = queue.shift()
+      state.readyClaims.push({ id, bucket })
+      if (!id) {
+        response.writeHead(204)
+        response.end()
+        return
+      }
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id,
+            status: 'transcribing',
+            sourceKind: 'voice',
+            fileSize: id === 'fresh-ready-job' ? 12 : 60000000,
+            recognitionLanguageHint: 'en',
+            localSourcePath: path.join(workDir, `${id}.ogg`),
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    const transcribeMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/transcribe$/
+    )
+    if (request.method === 'POST' && transcribeMatch) {
+      const id = transcribeMatch[1]
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          job: {
+            id,
+            status: 'transcribing',
+            sourceKind: 'voice',
+            fileSize: id === 'fresh-ready-job' ? 12 : 60000000,
+            recognitionLanguageHint: 'en',
+            attempts: 1,
+          },
+        })
+      )
+      return
+    }
+
+    const resultMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/result$/
+    )
+    if (request.method === 'POST' && resultMatch) {
+      state.results.push(resultMatch[1])
+      await readJson(request)
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(
+        JSON.stringify({ job: { id: resultMatch[1], status: 'completed' } })
+      )
+      return
+    }
+
+    const heartbeatMatch = url.pathname.match(
+      /^\/worker\/v1\/jobs\/([^/]+)\/heartbeat$/
+    )
+    if (request.method === 'POST' && heartbeatMatch) {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify({ job: { id: heartbeatMatch[1] } }))
+      return
+    }
+
+    if (request.method === 'POST' && url.pathname === '/worker/v1/jobs/claim') {
+      response.writeHead(204)
+      response.end()
+      return
+    }
+
+    response.writeHead(404, { 'Content-Type': 'application/json' })
+    response.end(JSON.stringify({ error: 'not_found' }))
+  })
+
+  return { server, state }
+}
+
 function createRestartProofServer() {
   const state = {
     claimDownloadAttempts: 0,
@@ -1769,6 +1889,72 @@ async function main() {
     )
   } finally {
     await close(fairBacklogProof.server)
+  }
+
+  const readyBacklogProof = createReadyBacklogRecoveryProofServer()
+  await listen(readyBacklogProof.server)
+
+  try {
+    const baseUrl = `http://127.0.0.1:${
+      readyBacklogProof.server.address().port
+    }/worker/v1`
+    const readyLogLines = []
+    const readyWorkerDir = path.join(
+      os.tmpdir(),
+      `voicy-worker-ready-backlog-proof-${process.pid}`
+    )
+    fs.mkdirSync(readyWorkerDir, { recursive: true })
+    const processed = await processAvailableJobs(
+      loadConfig({
+        VOICY_WORKER_API_URL: baseUrl,
+        VOICY_WORKER_TOKEN: 'proof-worker-token',
+        VOICY_WORKER_TRANSCRIBE_EXECUTABLE: process.execPath,
+        VOICY_WORKER_TRANSCRIBE_ARGS_JSON: JSON.stringify([
+          'scripts/fake-transcriber.js',
+          '{input}',
+          '{output}',
+        ]),
+        VOICY_WORKER_WORK_DIR: readyWorkerDir,
+        VOICY_WORKER_DOWNLOAD_CONCURRENCY: '1',
+        VOICY_WORKER_TRANSCRIPTION_CONCURRENCY: '1',
+        VOICY_WORKER_READY_QUEUE_LIMIT: '2',
+      }),
+      {
+        info: (message) => readyLogLines.push(message),
+        warn: (message) => readyLogLines.push(message),
+        error: (message) => readyLogLines.push(message),
+      }
+    )
+
+    assert(
+      processed === 3,
+      'ready backlog scheduler should process all recovered ready jobs'
+    )
+    assert(
+      readyBacklogProof.state.results.join(',') ===
+        'old-ready-1,fresh-ready-job,old-ready-2',
+      `fresh ready job should alternate in before the older ready backlog drains: ${readyBacklogProof.state.results.join(
+        ','
+      )}`
+    )
+    assert(
+      readyBacklogProof.state.readyClaims.some(
+        (claim) => claim.id === 'fresh-ready-job' && claim.bucket === 'newest'
+      ),
+      'fresh ready job should be recovered from the newest claim-ready bucket'
+    )
+    assert(
+      readyLogLines.some(
+        (line) =>
+          line.includes('Worker recovered ready job selected') &&
+          line.includes('jobId="fresh-ready-job"') &&
+          line.includes('claimBucket="newest"') &&
+          line.includes('schedulingBucket="newest"')
+      ),
+      'worker should log the recovered ready claim and scheduling bucket'
+    )
+  } finally {
+    await close(readyBacklogProof.server)
   }
 
   const restartProof = createRestartProofServer()

--- a/src/workerClient/runWindowsWorker.ts
+++ b/src/workerClient/runWindowsWorker.ts
@@ -1138,6 +1138,7 @@ export async function processAvailableJobs(
   let recheckDownloadsAfterTranscription = false
   let hasObservedDownloadExhaustion = false
   let nextDownloadBucket: WorkerQueueBucket = 'oldest'
+  let nextRecoveredReadyBucket: WorkerQueueBucket = 'oldest'
   let nextTranscriptionBucket: WorkerQueueBucket = 'oldest'
   let processed = 0
 
@@ -1204,20 +1205,29 @@ export async function processAvailableJobs(
       transcriptions.size + queuedReadyCount() <
       config.transcriptionConcurrency
     ) {
-      const job = await claimReadyJob(api, 'oldest')
+      const preferred = nextRecoveredReadyBucket
+      const alternate = preferred === 'oldest' ? 'newest' : 'oldest'
+      let claimBucket = preferred
+      let job = await claimReadyJob(api, claimBucket)
+      if (!job) {
+        claimBucket = alternate
+        job = await claimReadyJob(api, claimBucket)
+      }
       if (!job?.localSourcePath) {
         return
       }
       processed += 1
       logWorkerActivity(logger, 'Worker recovered ready job selected', {
         ...jobLogContext(job),
-        schedulingBucket: 'recovered',
+        claimBucket,
+        schedulingBucket: claimBucket,
         inputFile: path.basename(job.localSourcePath),
       })
+      nextRecoveredReadyBucket = claimBucket === 'oldest' ? 'newest' : 'oldest'
       queueReadyJob({
         job,
         inputPath: job.localSourcePath,
-        schedulingBucket: 'recovered',
+        schedulingBucket: claimBucket,
       })
     }
   }


### PR DESCRIPTION
## Summary
- alternate recovered `claim-ready` scheduling between oldest and newest buckets
- queue recovered ready jobs into the same old/new scheduler buckets so fresh ready work can run between stale backlog jobs
- add a worker-client regression proof for already-ready backlog recovery and update worker docs

## Validation
- `yarn build-ts`
- `yarn test:worker-client`
- `yarn lint`

Manual QA: required after deploy. Send a fresh short Telegram voice while ready backlog remains non-empty and confirm worker logs show recovered ready `claimBucket`/`schedulingBucket` alternation and prompt completion.